### PR TITLE
Initial  delete user account

### DIFF
--- a/components/FAQBottomSheet.tsx
+++ b/components/FAQBottomSheet.tsx
@@ -5,29 +5,147 @@ import { View, Text, TouchableOpacity, Alert, TextInput } from "react-native";
 import Collapsible from "react-native-collapsible";
 import { doc, updateDoc } from "firebase/firestore";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
-import { getStorage, ref, deleteObject } from "firebase/storage";
+import { deleteObject, ref, getStorage } from "firebase/storage";
 import { EmailAuthProvider } from "firebase/auth";
 import { reauthenticateWithCredential } from "firebase/auth";
-import { useNavigation } from "@react-navigation/native";
 
 import { FIREBASE_FIRESTORE, FIREBASE_AUTH } from "../firebaseConfig";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-const FAQBottomSheet = () => {
+const FAQBottomSheet = ({ navigation }: { navigation: any }) => {
+  // reference to the bottom sheet modal
+  const bottomSheetModalRef = useRef<typeof BottomSheetModal>(null);
+
+  // FAQ section states
   const [expandedSections, setExpandedSections] = useState<{
     [key: string]: boolean;
   }>({
-    accountDeletion: false,
     faq1: false,
     faq2: false,
+    faq3: false,
   });
 
+  // function to open or close a FAQ section
   const toggleSection = (section: string) => {
     setExpandedSections((prevState) => ({
       ...prevState,
       [section]: !prevState[section],
     }));
+  };
+
+  // states for delete account
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  // get the current user
+  const user = FIREBASE_AUTH.currentUser;
+  const userUid = user ? user.uid : null;
+
+  // function to close the FAQ bottom sheet modal
+  const closeFAQSheet = () => {
+    // condition to check if the bottomSheetModalRef is defined
+    if (bottomSheetModalRef.current) {
+      // if defined, close the modal
+      (bottomSheetModalRef.current as any).close();
+    }
+  };
+
+  // reauthenticate the user in Firebase Auth
+  const reauthenticateUser = async (password: string) => {
+    if (!user) {
+      throw new Error("No user is signed in.");
+    }
+    // create a credential with the user's email and password
+    const credential = EmailAuthProvider.credential(user.email!, password);
+
+    try {
+      // reauthenticate the user
+      await reauthenticateWithCredential(user, credential);
+      // console.log("Reauthentication successful");
+    } catch (error) {
+      console.error("Error during reauthentication:", error);
+      throw error;
+    }
+  };
+
+  // function to delete an image from Firebase Storage
+  const deleteImageFromStorage = async (imagePath: string) => {
+    // check if Firebase Storage is enabled
+    if (process.env.FIREBASE_STORAGE_ENABLED === "false") {
+      //  console.log("Skipping image deletion: Firebase Storage is disabled.");
+      return;
+    }
+
+    const storage = getStorage();
+    const imageRef = ref(storage, imagePath);
+
+    try {
+      await deleteObject(imageRef);
+      // console.log("Image deleted successfully.");
+    } catch (error: any) {
+      if (error.code === "storage/object-not-found") {
+        console.log("Image not found. Skipping delete.");
+      } else {
+        console.error("Error deleting image:", error);
+      }
+    }
+  };
+
+  // function to mark user data as inactive
+  const markUserDataAsInactive = async (userUid: string) => {
+    try {
+      const userRef = doc(FIREBASE_FIRESTORE, "Users", userUid);
+      await updateDoc(userRef, { isActive: false }); // marking the data as inactive
+      // console.log("User data marked as inactive");
+    } catch (error) {
+      console.error("Error marking user data as inactive:", error);
+      throw error;
+    }
+  };
+
+  // function to handle account deletion
+  const handleDeleteAccount = async () => {
+    if (!password) {
+      Alert.alert("Error", "Please enter your password.");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      if (!userUid) {
+        throw new Error("No user is signed in.");
+      }
+
+      await reauthenticateUser(password);
+      await deleteImageFromStorage(`profilePictures/${userUid}`);
+      await markUserDataAsInactive(userUid); // mark data as inactive before deletion
+      await FIREBASE_AUTH.currentUser?.delete();
+      // alert info to user that account has been deleted
+      Alert.alert("Success", "Your account has been deleted.");
+
+      closeFAQSheet();
+
+      // navigate to the login screen with a small delay
+      setTimeout(() => {
+        if (navigation && navigation.reset) {
+          navigation.reset({
+            index: 0,
+            routes: [{ name: "LoginScreen" }],
+          });
+        }
+      }, 500); // a small delay to ensure smooth transition
+    } catch (error: any) {
+      console.error("Error deleting account:", error);
+      // alert error to user
+      Alert.alert(
+        "Error",
+        "There was an issue deleting your account: " + error.message
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -70,25 +188,28 @@ const FAQBottomSheet = () => {
 
       {/* FAQ 3: Konto löschen */}
       <TouchableOpacity
-        onPress={() => toggleSection("accountDeletion")}
+        onPress={() => toggleSection("faq3")}
         style={{ flexDirection: "row", alignItems: "center", marginBottom: 10 }}
       >
         <Text style={{ fontSize: 16, fontWeight: "bold" }}>
           How to delete my account?
         </Text>
         <Text style={{ marginLeft: 10, fontSize: 18 }}>
-          {expandedSections.accountDeletion ? "↑" : "↓"}
+          {expandedSections.faq3 ? "↑" : "↓"}
         </Text>
       </TouchableOpacity>
-      <Collapsible collapsed={!expandedSections.accountDeletion}>
+      <Collapsible collapsed={!expandedSections.faq3}>
         <Text style={{ marginTop: 10, fontSize: 14, color: "#555" }}>
           To delete your account, you must confirm your password. If you delete
           your account, your data will no longer exist the next time you
           register.
         </Text>
+        {/* Password Input Field */}
         <TextInput
           placeholder="add your password"
           secureTextEntry
+          value={password}
+          onChangeText={setPassword}
           style={{
             borderWidth: 1,
             borderRadius: 5,
@@ -97,7 +218,9 @@ const FAQBottomSheet = () => {
             borderColor: "#ccc",
           }}
         />
+        {/*Button to delete account */}
         <TouchableOpacity
+          onPress={handleDeleteAccount}
           style={[
             {
               backgroundColor: "red",
@@ -111,7 +234,7 @@ const FAQBottomSheet = () => {
           <Text
             style={{ color: "white", textAlign: "center", fontWeight: "bold" }}
           >
-            {"Delete Account"}
+            {loading ? "deleting..." : "Delete Account"}
           </Text>
         </TouchableOpacity>
       </Collapsible>

--- a/firebaseConfig.ts
+++ b/firebaseConfig.ts
@@ -6,6 +6,7 @@ import {
   Auth,
 } from "firebase/auth";
 import { getFirestore, Firestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getAnalytics, isSupported } from "firebase/analytics";
@@ -50,6 +51,9 @@ try {
 // initialize Firestore
 const firestore: Firestore = getFirestore(app);
 
+// initialize Storage
+const storage = getStorage(app);
+
 // initialize Analytics when supported
 isSupported().then((supported) => {
   if (supported) {
@@ -72,4 +76,5 @@ export {
   app as FIREBASE_APP,
   authInstance as FIREBASE_AUTH,
   firestore as FIREBASE_FIRESTORE,
+  storage as FIREBASE_STORAGE,
 };


### PR DESCRIPTION
FAQBottomSheet.tsx:

Today I implemated an opportunity for the user to delete the account. 
If the user add his passowort in the FAQ-section and pushes the delete button, the handleDeletefunction will be activated and a reauthentication function will triggert, which I also in the file implemated. 
After this function, will trigger the deleteImageFromStorage, which only will triggert if a image exciste. 
I also implemated the condition that the deleteImageFromStorage only will triggert if the Firebase Blaze plan is active. 
If Spark is active it will ignored (the Spark plan will deaktivate from Firebase in the Summer 2025). 
Until then, I use this solution to minimise the costs because Firebase Storage and Cloud Functions generates more costs yet until the Blaze plan update isn´t roll out. 
In this case I  add a the isAktive:false stamp in Firestore to markt the user who has deleted his account to inactive and delete the data manual. 
This will minimiese my costs in this portfolio app currently. After that the user account will be delete with a FIREBASE_AUTH call. When these functions are over the FAQBottomSheet modal will close and the user will be navigate back to the LoginScreen.

firebaseConfig.ts:

I added a FIREBASE_STORAGE:false reference in the firebaseConfig zu get a request if Storage is aktive or not.