### PR TITLE
Feature  function to close tooltip

### DIFF
--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -3,7 +3,7 @@
 // this file mounts the WorkHoursChart in the WorkHoursScreen
 // it includes the bar chart and the tooltip with the position options and the data maping function
 
-import { View, Text } from "react-native";
+import { View, Text, TouchableWithoutFeedback } from "react-native";
 import React, { useState } from "react";
 import { BarChart } from "react-native-gifted-charts";
 
@@ -27,23 +27,22 @@ const WorkHoursChart = () => {
   // function to handle bar press
   const handleBarPress = (item: any, index: number) => {
     if (item?.stacks) {
+      // define the expected hours and over hours
       const expectedHours = item.stacks[0]?.value || 0;
       const overHours = item.stacks[1]?.value || 0;
 
+      //define the tooltip position options
       const barWidth = 22;
       const spacing = 24;
       const chartHeight = 400;
-      const scaleFactor = 10; // pixel to hour
+      const scaleFactor = 15; // pixel to hour
+      const tooltipHeight = 80;
 
       const x = index * (barWidth + spacing) + barWidth / 2;
-      const highestPoint = (expectedHours + overHours) * scaleFactor;
-      let y = chartHeight - highestPoint - 40;
 
-      // options to position the tooltip in Y if it is too high
-      if (y < 50) y = 50;
-
-      // options to position the tooltip in Y if it is too low
-      if (y > chartHeight - 100) y = chartHeight - 280;
+      // calcuklate y position dynamic
+      let y =
+        chartHeight - (expectedHours + overHours) * scaleFactor - tooltipHeight;
 
       // atjust x position
       let adjustedX = x;
@@ -58,13 +57,7 @@ const WorkHoursChart = () => {
         x: adjustedX,
         y: y,
       });
-      console.log("Tooltip Position:", {
-        x: adjustedX,
-        y: y,
-        highestPoint,
-        expectedHours,
-        overHours,
-      });
+      //console.log(tooltipData);
     }
   };
   // function to  filter an maping the values and define the data for the bar chart
@@ -95,131 +88,135 @@ const WorkHoursChart = () => {
     .filter((item) => item !== null);
 
   return (
-    <View
-      style={{
-        marginTop: 50,
-        width: "100%",
-        height: 480,
-        borderWidth: 1,
-        borderColor: "aqua",
-        borderRadius: 12,
-        backgroundColor: "#191919",
-      }}
-    >
-      {/*Title */}
-      <Text
-        style={{
-          fontFamily: "MPLUSLatin_Bold",
-          fontSize: 25,
-          color: "white",
-          marginBottom: 80,
-          marginTop: 25,
-          textAlign: "center",
-        }}
-      >
-        Workhours Chart
-      </Text>
-      <ChartRadioButtons />
-      {/*Stacked Bar Chart */}
-      <BarChart
-        width={290}
-        //rotateLabel
-        maxValue={12}
-        noOfSections={6}
-        stackData={stackData}
-        barWidth={30}
-        initialSpacing={5}
-        spacing={28}
-        barBorderRadius={2.5}
-        isAnimated
-        yAxisColor={"darkgray"}
-        xAxisColor={"darkgray"}
-        xAxisLabelTextStyle={{ color: "white" }}
-        yAxisTextStyle={{ color: "white" }}
-        onPress={(item: any, index: number) => handleBarPress(item, index)}
-      />
-
-      {/*Legend Container */}
+    // touchable without feedback to close the tooltip
+    <TouchableWithoutFeedback onPress={() => setTooltipData(null)}>
       <View
         style={{
-          flexDirection: "row",
-          justifyContent: "center",
-          alignItems: "center",
-          marginTop: 25,
-          marginBottom: 15,
+          marginTop: 50,
+          width: "100%",
+          height: 480,
+          borderWidth: 1,
+          borderColor: "aqua",
+          borderRadius: 12,
+          backgroundColor: "#191919",
         }}
       >
+        {/* Title */}
+        <Text
+          style={{
+            fontFamily: "MPLUSLatin_Bold",
+            fontSize: 25,
+            color: "white",
+            marginBottom: 80,
+            marginTop: 25,
+            textAlign: "center",
+          }}
+        >
+          Workhours Chart
+        </Text>
+        <ChartRadioButtons />
+        {/* Stacked Bar Chart */}
+
+        <BarChart
+          width={290}
+          //rotateLabel
+          maxValue={12}
+          noOfSections={6}
+          stackData={stackData}
+          barWidth={30}
+          initialSpacing={5}
+          spacing={28}
+          barBorderRadius={2.5}
+          isAnimated
+          yAxisColor={"darkgray"}
+          xAxisColor={"darkgray"}
+          xAxisLabelTextStyle={{ color: "white" }}
+          yAxisTextStyle={{ color: "white" }}
+          onPress={(item: any, index: number) => handleBarPress(item, index)}
+        />
+
+        {/* Legend Container */}
         <View
           style={{
             flexDirection: "row",
+            justifyContent: "center",
             alignItems: "center",
-            marginHorizontal: 10,
+            marginTop: 25,
+            marginBottom: 15,
           }}
         >
           <View
             style={{
-              height: 12,
-              width: 12,
-              borderRadius: 6,
-              backgroundColor: "gray",
+              flexDirection: "row",
+              alignItems: "center",
+              marginHorizontal: 10,
             }}
-          />
-          <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
-            Expected Hours
-          </Text>
-        </View>
-        <View
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            marginHorizontal: 10,
-          }}
-        >
+          >
+            <View
+              style={{
+                height: 12,
+                width: 12,
+                borderRadius: 6,
+                backgroundColor: "gray",
+              }}
+            />
+            <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
+              Expected Hours
+            </Text>
+          </View>
           <View
             style={{
-              height: 12,
-              width: 12,
-              borderRadius: 6,
-              backgroundColor: "aqua",
+              flexDirection: "row",
+              alignItems: "center",
+              marginHorizontal: 10,
             }}
-          />
-          <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
-            Over Hours
-          </Text>
+          >
+            <View
+              style={{
+                height: 12,
+                width: 12,
+                borderRadius: 6,
+                backgroundColor: "aqua",
+              }}
+            />
+            <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
+              Over Hours
+            </Text>
+          </View>
         </View>
+        {/* Tooltip Box */}
+        {tooltipData && (
+          <View
+            style={{
+              position: "absolute",
+              width: 115,
+              height: 80,
+              justifyContent: "space-around",
+              top: tooltipData.y,
+              left: tooltipData.x,
+              backgroundColor: "#333",
+              padding: 8,
+              borderRadius: 8,
+              elevation: 5,
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.5,
+              shadowRadius: 4,
+            }}
+          >
+            <Text style={{ fontSize: 14, color: "white", fontWeight: "bold" }}>
+              {`📅 ${tooltipData.date}`}
+            </Text>
+            <Text style={{ fontSize: 12, color: "white" }}>
+              {`⏳ Expected: ${tooltipData.expectedHours}h`}
+            </Text>
+            <Text style={{ fontSize: 12, color: "aqua" }}>
+              {`🚀 Over: ${tooltipData.overHours}h`}
+            </Text>
+          </View>
+        )}
       </View>
-      {/*Tooltip Box */}
-      {tooltipData && (
-        <View
-          style={{
-            position: "absolute",
-            width: 115,
-            height: 80,
-            justifyContent: "space-around",
-            top: tooltipData.y,
-            left: tooltipData.x,
-            backgroundColor: "#333",
-            padding: 8,
-            borderRadius: 8,
-            elevation: 5,
-            shadowColor: "#000",
-            shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.5,
-            shadowRadius: 4,
-          }}
-        >
-          <Text style={{ fontSize: 14, color: "white", fontWeight: "bold" }}>
-            {`📅 ${tooltipData.date}`}
-          </Text>
-          <Text style={{ fontSize: 12, color: "white" }}>
-            {`⏳ Expected: ${tooltipData.expectedHours}h`}
-          </Text>
-          <Text style={{ fontSize: 12, color: "aqua" }}>
-            {`🚀 Over: ${tooltipData.overHours}h`}
-          </Text>
-        </View>
-      )}
-    </View>
+    </TouchableWithoutFeedback>
   );
 };
 


### PR DESCRIPTION
### Titel
Add a function to close the tooltip

## Description
**Summary**
This PR adds an onPress function to close the tooltip when the user presses outside the chart.

**Motivation**
To give the user the option to close the tooltip window.

**Changes**
- Added a TouchableWithoutFeedback and wrapped the card that contains the chart
- Added an onPress arrow function to reset the state to the initial state
- Change the tooltip position parameters and definitions to get dynamic behavior

## Test Instructions
**How ​​to test**
1. Press a bar and watch what is rendered.
2. Press outside the chart and see if the tooltip closes.
3. Check console.log to see if the X and Y position is as expected.

**Expected Result**
The user closes the tooltip when he/she has pressed out of the chart.




## Additional Information
**Known Issues**
None


**Dependencies**
No changes.