### PR TITLE
feat: change local date code and add a date condition to the year chart

### DIFF
--- a/components/FormatToolTip.ts
+++ b/components/FormatToolTip.ts
@@ -1,9 +1,16 @@
 //////////////////////////FormatToolTip.ts//////////////////////////////////////
 
 // This modul is used to format the date in the WorkHours chart tooltip
-export const formatTooltipDate = (dateString?: string): string => {
+export const formatTooltipDate = (
+  dateString?: string,
+  chartType?: string
+): string => {
   if (!dateString) return "No date available";
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return "unknown date";
-  return `${date.toLocaleDateString("de-DE", { weekday: "long" })}\n${date.toLocaleDateString("de-DE", { day: "2-digit", month: "long" })}`;
+  // condition: if the chart type is "year" only show the month
+  if (chartType === "year") {
+    return date.toLocaleDateString("en-GB", { month: "long" });
+  }
+  return `${date.toLocaleDateString("en-GB", { weekday: "long" })}\n${date.toLocaleDateString("en-GB", { day: "2-digit", month: "long" })}`;
 };

--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -145,13 +145,13 @@ const WorkHoursChart = () => {
     const date = new Date(dateString);
     if (viewMode === "year") {
       return date
-        .toLocaleDateString("de-DE", { month: "short" })
+        .toLocaleDateString("en-GB", { month: "short" })
         .replace(".", "");
     } else if (viewMode === "month") {
-      return date.toLocaleDateString("de-DE", { day: "2-digit" });
+      return date.toLocaleDateString("en-GB", { day: "2-digit" });
     }
     // Week-Chart is the default
-    return date.toLocaleDateString("de-DE", { day: "2-digit" });
+    return date.toLocaleDateString("en-GB", { day: "2-digit" });
   };
 
   // section that maps the data to the bar chart and calculates the year chart bar for every month
@@ -175,12 +175,17 @@ const WorkHoursChart = () => {
     });
     // map the monthly sums to the bar chart and format the x-axis labels
     stackData = Object.keys(monthlySums).map((key) => {
+      // split the key into year and month
       const [year, month] = key.split("-");
-      const monthName = new Date(Number(year), Number(month), 1)
-        .toLocaleDateString("de-DE", { month: "short" })
+      // create a date object for the month
+      const dateForMonth = new Date(Number(year), Number(month), 1);
+      // format the date
+      const monthName = dateForMonth
+        .toLocaleDateString("en-GB", { month: "short" })
         .replace(".", "");
       return {
         label: monthName,
+        originalDate: dateForMonth.toISOString(),
         stacks: [
           { value: monthlySums[key].expected, color: "gray" },
           { value: monthlySums[key].over, color: "aqua", marginBottom: 2 },
@@ -383,7 +388,7 @@ const WorkHoursChart = () => {
             }}
           >
             <Text style={{ fontSize: 14, color: "white", fontWeight: "bold" }}>
-              {`📅 ${formatTooltipDate(tooltipData.date)}`}
+              {`📅 ${formatTooltipDate(tooltipData.date, chartType)}`}
             </Text>
             <Text style={{ fontSize: 12, color: "white" }}>
               {`⏳ Expected: ${tooltipData.expectedHours}h`}


### PR DESCRIPTION
### Titel
Enshure monthly date in the year chart tooltip


## Description
**Summary**
This PR updates the yearly chart tooltip to enshure the date is a month date and not invalid date.
It also includes an update in the UTC type.


**Motivation**
To enshure the labels has the UTC type as expected and set the expected month in the tooltip when user switches to the year chart.


**Changes**
- Update the UTC type to "en-GB"
- Add a condition to get the month name in the year chart tooltip



## Test Instructions
**How to test**
1. Navigate to the WorkHoursScreen and watch if the right UTC type is rendered in the x-axis and switch to the year chart view and click on a bar to watch if the month name is inside the tooltip.


**Expected Result**
The user should geht the right x-axis label and get the right month name .



## Additional Information
**Known Issues**
None


**Dependencies**
No changes.