### PR TITLE
feat: enshure max. 2 decimal places

### DIFF
--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -394,7 +394,7 @@ const WorkHoursChart = () => {
               {`⏳ Expected: ${tooltipData.expectedHours}h`}
             </Text>
             <Text style={{ fontSize: 12, color: "aqua" }}>
-              {`🚀 Over: ${tooltipData.overHours}h`}
+              {`🚀 Over: ${(tooltipData.overHours || 0).toFixed(2)}h`}
             </Text>
           </View>
         )}


### PR DESCRIPTION
### Titel
Add method to enshure maximum 2 decimal places


## Description
**Summary**
This PR adds a method to show maximum 2 decimal places in the tooltip.


**Motivation**
To enshure maximum 2 decimal places when the overHours in the year chart renders.


**Changes**
- Modified the calculated data with a toFixed method




## Test Instructions
**How to test**
1. Lokk in the year chart tooltip that only 2 decimal places are rendering.



**Expected Result**
The user should see maximum 2 decimal places in the year chart tooltip wehre overHours are rendering.


## Additional Information
**Known Issues**
None


**Dependencies**
No changes.