### PR TITLE
feature: disable start button if user doesn´t add value for expected daily working hours

### DIFF
--- a/components/VacationRemindModal.tsx
+++ b/components/VacationRemindModal.tsx
@@ -10,8 +10,8 @@ import { View, Text, TouchableOpacity, Alert } from "react-native";
 import Modal from "react-native-modal";
 import { LinearGradient } from "expo-linear-gradient";
 import { doc, setDoc, getDoc } from "firebase/firestore";
-import { NotificationManager } from "./services/PushNotifications";
 
+import { NotificationManager } from "./services/PushNotifications";
 import { FIREBASE_AUTH, FIREBASE_FIRESTORE } from "../firebaseConfig";
 import CheckmarkAnimation from "./Checkmark";
 

--- a/components/WorkHoursState.tsx
+++ b/components/WorkHoursState.tsx
@@ -19,6 +19,7 @@ interface WorkHoursStateProps {
   useTimeZone: string;
   workData: any[];
   expectedHours: string;
+  docExists: boolean;
   startWorkTime: Date | null;
   isWorking: boolean;
   elapsedTime: number;
@@ -29,6 +30,7 @@ interface WorkHoursStateProps {
 
   saveState: () => Promise<void>;
   loadState: () => Promise<void>;
+  setDocExists: (value: boolean) => void;
   setUserTimeZone: (timeZone: string) => void;
   setWorkData: (data: any[]) => void;
   setExpectedHours: (hours: string) => void;
@@ -49,6 +51,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
   useTimeZone: "",
   workData: [],
   expectedHours: "",
+  docExists: false,
   startWorkTime: null,
   isWorking: false,
   elapsedTime: 0,
@@ -109,13 +112,14 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
       state.currentDocId || "defaultDocId"
     );
 
-    await setDoc(docRef, stateToSave); // save only the necessary fields
+    await setDoc(docRef, stateToSave);
   },
 
   // actions to update the workhoursstate
   setUserTimeZone: (timeZone) => set({ useTimeZone: timeZone }),
   setWorkData: (data) => set({ workData: data }),
   setExpectedHours: (hours) => set({ expectedHours: hours }),
+  setDocExists: (value) => set({ docExists: value }),
   setStartWorkTime: (time) => set({ startWorkTime: time }),
   setIsWorking: (working) => set({ isWorking: working }),
   setElapsedTime: (time) => set({ elapsedTime: time }),


### PR DESCRIPTION
## Titel  
Add a start button hide feature

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [x] 📖 docs: Dokumentation changes  
- [x] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [x] 🎭 ui: Ui changes  

## Changes  
This PR adds a condition to disable the Start button if the user doesn't enter a value for the expected work hours.
When the button is enabled, its color changes from gray to blue and it can be pressed.
I'm also removed the old condition that sends an alert if the expected work hours aren't set.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
 My changes are well-tested and commented
 I reviewed my changes
 My changes generate no new warnings