### PR TITLE
Bugfix  reset format time

### DIFF
--- a/components/WorkTimeTracker.tsx
+++ b/components/WorkTimeTracker.tsx
@@ -315,7 +315,6 @@ const WorkTimeTracker = () => {
     const endTime = new Date();
     // calculate the duration of the current session (in hours)
     const sessionDurationHours = calculateElapsedTime(startWorkTime);
-    // full duration = accumulated duration + current session
     const totalDuration = accumulatedDuration + sessionDurationHours;
     const roundedDuration = parseFloat(totalDuration.toFixed(2));
     const overHours = roundedDuration - parseFloat(expectedHours);
@@ -340,6 +339,7 @@ const WorkTimeTracker = () => {
         endTime: endTime.toISOString(),
         duration: roundedDuration,
         overHours: Math.max(roundedOverHours, 0),
+        elapsedTime: roundedDuration,
       });
       // console.log(
       //   "Data successfully updated with total duration:",
@@ -354,6 +354,7 @@ const WorkTimeTracker = () => {
     // update the local accumulated duration and reset the start time
     setAccumulatedDuration(roundedDuration);
     setStartWorkTime(null);
+    setElapsedTime(roundedDuration); // to hold the total duration only if it´s the current day
   };
 
   // function to get the data from firestore


### PR DESCRIPTION
## Titel  
Keep the elapsed time after stopping the timer

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [ ] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
 This PR adds elapsedTime: roundedDuration to the stop function, 
to ensure that the formateTime show only 00:00 if it´s not the current day.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
 My changes are well-tested and commented
 I reviewed my changes
 My changes generate no new warnings