### PR TITLE
Bugfix  close faq modal after delete account

### DIFF
--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -560,7 +560,7 @@ const HomeScreen: React.FC = () => {
             >
               <WalkthroughTextInput
                 style={{
-                  width: screenWidth * 0.9, // dynamische width (90%)
+                  width: screenWidth * 0.9, // use 90% of the screen width
                   maxWidth: 320,
                   borderColor: "aqua",
                   borderWidth: 1.5,

--- a/components/CustomDrawer.tsx
+++ b/components/CustomDrawer.tsx
@@ -52,6 +52,7 @@ const CustomDrawer: React.FC<CustomDrawerProps> = (props) => {
   // BottomSheetModal settings
   // reference to the bottom sheet modal
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+
   // snap points for the bottom sheet modal
   const snapPoints = useMemo(() => ["25%", "50%"], []);
   // callback to handle the presentation of the bottom sheet modal

--- a/components/FAQBottomSheet.tsx
+++ b/components/FAQBottomSheet.tsx
@@ -22,9 +22,9 @@ import { deleteObject, ref, getStorage } from "firebase/storage";
 import { EmailAuthProvider } from "firebase/auth";
 import { reauthenticateWithCredential } from "firebase/auth";
 import { FontAwesome5 } from "@expo/vector-icons";
+import { ScrollView } from "react-native-gesture-handler";
 
 import { FIREBASE_FIRESTORE, FIREBASE_AUTH } from "../firebaseConfig";
-import { ScrollView } from "react-native-gesture-handler";
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -154,19 +154,10 @@ const FAQBottomSheet = ({ navigation, closeModal }: FAQBottomSheetProps) => {
       Alert.alert("Success", "Your account has been deleted.", [
         {
           text: "OK",
-          onPress: () => {
-            navigation.reset({
-              index: 0,
-              routes: [{ name: "LoginScreen" }],
-            });
-          },
         },
       ]);
       // delete account from Firebase after navigate to LoginScreen
       await FIREBASE_AUTH.currentUser?.delete();
-
-      // alert info to user that account has been deleted
-      Alert.alert("Success", "Your account has been deleted.");
     } catch (error: any) {
       console.error("Error deleting account:", error);
       // alert error to user

--- a/components/FAQBottomSheet.tsx
+++ b/components/FAQBottomSheet.tsx
@@ -149,21 +149,24 @@ const FAQBottomSheet = ({ navigation, closeModal }: FAQBottomSheetProps) => {
       await reauthenticateUser(password);
       await deleteImageFromStorage(`profilePictures/${userUid}`);
       await markUserDataAsInactive(userUid); // mark data as inactive before deletion
-      await FIREBASE_AUTH.currentUser?.delete();
-      // alert info to user that account has been deleted
-      Alert.alert("Success", "Your account has been deleted.");
-
       closeFAQSheet();
 
-      // navigate to the login screen with a small delay
-      setTimeout(() => {
-        if (navigation && navigation.reset) {
-          navigation.reset({
-            index: 0,
-            routes: [{ name: "LoginScreen" }],
-          });
-        }
-      }, 500); // a small delay to ensure smooth transition
+      Alert.alert("Success", "Your account has been deleted.", [
+        {
+          text: "OK",
+          onPress: () => {
+            navigation.reset({
+              index: 0,
+              routes: [{ name: "LoginScreen" }],
+            });
+          },
+        },
+      ]);
+      // delete account from Firebase after navigate to LoginScreen
+      await FIREBASE_AUTH.currentUser?.delete();
+
+      // alert info to user that account has been deleted
+      Alert.alert("Success", "Your account has been deleted.");
     } catch (error: any) {
       console.error("Error deleting account:", error);
       // alert error to user


### PR DESCRIPTION
## Titel  
Fix the close FAQ sheet function after deleting account

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [x] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR changes the handleDeleteAccount function to ensure that the FAQ bottom sheet modal is closing after deleting the account.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
 My changes are well-tested and commented
 I reviewed my changes
 My changes generate no new warnings