### PR TITLE
Feature  add guided tour in work hours screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -123,7 +123,7 @@ const AppDrawerNavigator = () => {
 
       <Drawer.Screen
         name="Flex"
-        component={WorkHoursScreen}
+        component={WorkHoursScreen as any}
         options={{
           // function to change the icon color when focused
           drawerActiveTintColor: "white",
@@ -143,7 +143,7 @@ const AppDrawerNavigator = () => {
       />
       <Drawer.Screen
         name="Vacation"
-        component={VacationScreen}
+        component={VacationScreen as any}
         options={{
           // function to change the icon color when focused
           drawerLabel: ({ focused }) => (
@@ -212,7 +212,7 @@ const App = () => {
         <BottomSheetModalProvider>
           {/* global copilot tour provider with tooltip options */}
           <CopilotProvider
-            overlay="view"
+            overlay="svg"
             verticalOffset={40}
             backdropColor="rgba(5, 5, 5, 0.59)"
             arrowColor="#ffffff"

--- a/Screens/DetailsScreen.tsx
+++ b/Screens/DetailsScreen.tsx
@@ -78,8 +78,8 @@ const DetailsScreen: React.FC<DetailsScreenProps> = () => {
   // state to show the copilot tour
   const [showTour, setShowTour] = useState<boolean>(false);
 
+  // hook to check AsyncStorage if the user has already seen the tour
   useEffect(() => {
-    // check if the user has seen the tour
     const hasSeenTour = AsyncStorage.getItem("hasSeenDetailsTour");
     if (!hasSeenTour) {
       setShowTour(true);
@@ -104,7 +104,7 @@ const DetailsScreen: React.FC<DetailsScreenProps> = () => {
   return (
     // local DetailsScreen Provider (important if you need to adress a child component to the copilot tour)
     <CopilotProvider
-      overlay="view"
+      overlay="svg"
       verticalOffset={40}
       backdropColor="rgba(5, 5, 5, 0.59)"
       arrowColor="#ffffff"

--- a/Screens/VacationScreen.tsx
+++ b/Screens/VacationScreen.tsx
@@ -9,7 +9,6 @@ import { View, Text, ScrollView } from "react-native";
 import React, { useEffect, useState, useRef } from "react";
 import { useRoute } from "@react-navigation/native";
 import { getAuth, Auth } from "firebase/auth";
-import { FIREBASE_APP } from "../firebaseConfig";
 import LottieView from "lottie-react-native";
 import { useIsFocused } from "@react-navigation/native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -18,6 +17,7 @@ import { CopilotProvider } from "react-native-copilot";
 import CustomCalendar from "../components/CustomCalendar";
 import VacationForm from "../components/VacationForm";
 import VacationList from "../components/VacationList";
+import { FIREBASE_APP } from "../firebaseConfig";
 import TourButton from "../components/TourButton";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -47,6 +47,7 @@ const VacationScreen: React.FC<VacationScreenRouteProps> = () => {
   // state to show the copilot tour
   const [showTour, setShowTour] = useState<boolean>(false);
 
+  // hook to check AsyncStorage if the user has already seen the tour
   useEffect(() => {
     AsyncStorage.getItem("hasSeenVacationTour").then((hasSeenTour) => {
       if (!hasSeenTour) {
@@ -72,7 +73,7 @@ const VacationScreen: React.FC<VacationScreenRouteProps> = () => {
   return (
     // local VacationScreen Provider (important if you need to adress a child component to the copilot tour)
     <CopilotProvider
-      overlay="view"
+      overlay="svg"
       verticalOffset={40}
       backdropColor="rgba(5, 5, 5, 0.59)"
       arrowColor="#ffffff"

--- a/Screens/WorkHoursScreen.tsx
+++ b/Screens/WorkHoursScreen.tsx
@@ -1,69 +1,138 @@
 /////////////////////////////////Workhours Screen////////////////////////////////////
 
-import React from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { View, Text, SafeAreaView, ScrollView } from "react-native";
+import { useRoute } from "@react-navigation/native";
+import { getAuth, Auth } from "firebase/auth";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { CopilotProvider } from "react-native-copilot";
 
+import { FIREBASE_APP } from "../firebaseConfig";
 import WorkHoursState from "../components/WorkHoursState";
 import WorkHoursInput from "../components/WorkHoursInput";
 import WorkTimeTracker from "../components/WorkTimeTracker";
 import WorkHoursChart from "../components/WorkHoursChart";
 import ErrorBoundary from "../components/ErrorBoundary";
+import TourButton from "../components/TourButton";
+import { customSvgMaskPath } from "../components/CustomSVGMaskPath";
 
 /////////////////////////////////////////////////////////////////////////////////////
 
-const WorkHoursScreen = () => {
+type WorkHoursScreenRouteProps = {
+  key: string;
+  name: string;
+  params: {
+    projectId: string;
+  };
+};
+
+//////////////////////////////////////////////////////////////////////////////////////
+
+const WorkHoursScreen: React.FC<WorkHoursScreenRouteProps> = () => {
+  //  initialize WorkHoursState
   const {} = WorkHoursState();
 
+  // initialize Firebase Auth
+  const auth: Auth = getAuth(FIREBASE_APP);
+  // initialize routing
+  const route = useRoute<WorkHoursScreenRouteProps>();
+  // get projectId from routing
+  const { projectId } = route.params || {};
+
+  // ref for the Scrollview to navigate to the copilot tour
+  const scrollViewRef = useRef<ScrollView>(null);
+  const [scrollViewReady, setScrollViewReady] = useState(false);
+
+  // state to show the copilot tour
+  const [showTour, setShowTour] = useState<boolean>(false);
+
+  // hook to check AsyncStorage if the user has already seen the tour
+  useEffect(() => {
+    AsyncStorage.getItem("hasSeenWorkHoursTour").then((hasSeenTour) => {
+      if (!hasSeenTour) {
+        setShowTour(true);
+      }
+    });
+  }, [projectId]);
+
   return (
-    <ScrollView
-      style={{
-        flex: 1,
-        height: "100%",
-        width: "100%",
+    <CopilotProvider
+      overlay="svg"
+      verticalOffset={40}
+      // custom maskpath for the WorkHoursChart
+      svgMaskPath={customSvgMaskPath}
+      backdropColor="rgba(5, 5, 5, 0.59)"
+      arrowColor="#ffffff"
+      tooltipStyle={{
+        backgroundColor: "#ffffff",
+        padding: 10,
+        borderRadius: 8,
+        marginTop: -10,
       }}
     >
-      <SafeAreaView
+      <ScrollView
+        // scrollview ref and onlayout to navigate to the copilot tour
+        ref={scrollViewRef}
+        onLayout={() => setScrollViewReady(true)}
         style={{
           flex: 1,
-          justifyContent: "center",
-          alignItems: "center",
+          height: "100%",
+          width: "100%",
         }}
       >
-        <View
+        <SafeAreaView
           style={{
             flex: 1,
-            minHeight: "100%",
             justifyContent: "center",
             alignItems: "center",
-            backgroundColor: "black",
-            padding: 16,
-            width: "100%",
-            height: "100%",
           }}
         >
-          <Text
+          <View
             style={{
-              fontSize: 25,
-              fontFamily: "MPLUSLatin_Bold",
-              color: "white",
-              marginBottom: 50,
+              flex: 1,
+              minHeight: "100%",
+              justifyContent: "center",
+              alignItems: "center",
+              backgroundColor: "black",
+              padding: 16,
+              width: "100%",
+              height: "100%",
             }}
           >
-            - Workhours Management -
-          </Text>
-          {/* WorkHours Input */}
-          <WorkHoursInput />
-          <View style={{ marginTop: 50, width: "100%", alignItems: "center" }}>
-            {/* Worktime Tracker */}
-            <ErrorBoundary>
-              <WorkTimeTracker />
-            </ErrorBoundary>
+            <Text
+              style={{
+                fontSize: 25,
+                fontFamily: "MPLUSLatin_Bold",
+                color: "white",
+                marginBottom: 50,
+              }}
+            >
+              - Workhours Management -
+            </Text>
+            {/* WorkHours Input */}
+            <WorkHoursInput />
+            <View
+              style={{ marginTop: 50, width: "100%", alignItems: "center" }}
+            >
+              {/* Worktime Tracker */}
+              <ErrorBoundary>
+                <WorkTimeTracker />
+              </ErrorBoundary>
+            </View>
+            {/* Workhours Chart */}
+            <WorkHoursChart />
           </View>
-          {/* Workhours Chart */}
-          <WorkHoursChart />
-        </View>
-      </SafeAreaView>
-    </ScrollView>
+        </SafeAreaView>
+      </ScrollView>
+      {/* Tour button for the copilot tour */}
+      <TourButton
+        storageKey={`hasSeenWorkHoursTour`}
+        userId={auth.currentUser?.uid ?? ""}
+        scrollViewRef={scrollViewRef}
+        scrollViewReady={scrollViewReady}
+        needsRefCheck={true}
+      />
+    </CopilotProvider>
   );
 };
 

--- a/components/CustomSVGMaskPath.tsx
+++ b/components/CustomSVGMaskPath.tsx
@@ -1,0 +1,50 @@
+/////////////////////////////CustomSVGMaskPath Component/////////////////////////////////////////////////////////////////////////////////////
+
+// This component creates a custom SVG mask path for the WorkHoursChart component.
+// It defines a mask that cuts a hole in the canvas, displaying the chart at the correct position with an additional 50px offset downwards.
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+import { Animated } from "react-native";
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+interface StepType {
+  name?: string; // optional: name of the current step, used to determine specific behavior
+  order?: number; // optional: order of the step, for sequencing
+}
+
+interface SvgMaskArguments {
+  size: Animated.ValueXY; // size of the area to mask
+  position: Animated.ValueXY; // position of the mask relative to the canvas
+  canvasSize: { x: number; y: number }; // dimensions of the canvas
+  step: StepType; // current step info for determining specific adjustments
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+export function customSvgMaskPath({
+  size,
+  position,
+  canvasSize,
+  step,
+}: SvgMaskArguments): string {
+  // apply an extra vertical offset if the step is 'WorkHoursChart' (50px downwards)
+  const extraY = step.name === "WorkHoursChart" ? 50 : 0;
+
+  // extract x and y positions from Animated.ValueXY
+  const x0 = (position.x as any).__getValue() as number;
+  const y0 = ((position.y as any).__getValue() as number) + extraY;
+
+  // calculate the bottom-right corner of the mask rectangle
+  const x1 = x0 + ((size.x as any).__getValue() as number);
+  const y1 = y0 + ((size.y as any).__getValue() as number);
+
+  // construct and return the SVG path string for the mask
+  return (
+    // create a rectangular mask for the entire canvas
+    `M0,0H${canvasSize.x}V${canvasSize.y}H0V0` +
+    // create an inner rectangle that will be "cut out" from the mask
+    `ZM${x0},${y0}H${x1}V${y1}H${x0}V${y0}Z`
+  );
+}

--- a/components/VacationForm.tsx
+++ b/components/VacationForm.tsx
@@ -6,14 +6,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 import React, { useState, useEffect } from "react";
-import {
-  Text,
-  View,
-  ScrollView,
-  TouchableOpacity,
-  Alert,
-  Dimensions,
-} from "react-native";
+import { Text, View, ScrollView, TouchableOpacity, Alert } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { LinearGradient } from "expo-linear-gradient";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
@@ -27,9 +20,6 @@ import { useCalendarStore } from "../components/CalendarState";
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
 const VacationForm = () => {
-  // screensize for dynamic size calculation
-  const screenWidth = Dimensions.get("window").width;
-
   // initial start and end dates states
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");

--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -15,6 +15,7 @@ import {
   Dimensions,
 } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
+import { CopilotStep, walkthroughable } from "react-native-copilot";
 
 import WorkHoursState from "../components/WorkHoursState";
 import ChartRadioButtons from "./ChartRadioButtons";
@@ -270,159 +271,177 @@ const WorkHoursChart = () => {
 
   const dynamicMaxValue = getDynamicMaxValue();
 
+  // modified walkthroughable for copilot tour
+  const CopilotTouchableView = walkthroughable(View);
+
   return (
-    // TouchableWithoutFeedback to close the tooltip
-    <TouchableWithoutFeedback onPress={() => setTooltipData(null)}>
-      <View
-        onLayout={(event: LayoutChangeEvent) =>
-          setCardWidth(event.nativeEvent.layout.width)
-        }
-        style={{
-          marginTop: 50,
-          width: screenWidth * 0.9, // dynamic 90% of the screen width
-          maxWidth: 600,
-          height: 480,
-          borderWidth: 1,
-          borderColor: "aqua",
-          borderRadius: 12,
-          backgroundColor: "#191919",
-        }}
+    <>
+      {/* DetailsScreen copilot tour step 2 */}
+      <CopilotStep
+        name="WorkHoursChart"
+        order={3}
+        text="This card shows the workhours and you overhours for the selected period. You can push on a bar to see the tracked details."
       >
-        {/* Titel */}
-        <Text
-          style={{
-            fontFamily: "MPLUSLatin_Bold",
-            fontSize: 25,
-            color: "white",
-            marginBottom: 80,
-            marginTop: 25,
-            textAlign: "center",
-          }}
-        >
-          Workhours Chart
-        </Text>
-        <ChartRadioButtons
-          chartType={chartType as "week" | "month" | "year"}
-          setChartType={(type) => {
-            setChartType(type);
-            setTooltipData(null); // close tooltip if chart type changes
-          }}
-        />
-        {/* Frame-Container with horizontal scrollbar */}
-        <View style={{ paddingHorizontal: cardPadding }}>
-          {/* Horizontal scrollbarer container for the BarChart */}
-          <ScrollView
-            horizontal
-            ref={scrollViewRef}
-            onScroll={(e) => setScrollX(e.nativeEvent.contentOffset.x)}
-            scrollEventThrottle={16}
-            contentContainerStyle={{ paddingRight: spacing + barWidth / 2 }}
-          >
-            <BarChart
-              width={computedChartWidth}
-              yAxisLabelSuffix="h"
-              stackData={stackData}
-              maxValue={dynamicMaxValue} // regulate the size of the Y-Axis
-              barWidth={barWidth}
-              initialSpacing={initialSpacing}
-              spacing={spacing}
-              barBorderRadius={2.5}
-              isAnimated
-              yAxisColor={"white"}
-              xAxisColor={"white"}
-              rulesColor={"dimgray"} // color for the horizontal break lines
-              xAxisLabelTextStyle={{ color: "white" }}
-              yAxisTextStyle={{ color: "white" }}
-              onPress={(item: any, index: number) =>
-                handleBarPress(item, index)
+        <CopilotTouchableView>
+          {/* TouchableWithoutFeedback to close the tooltip */}
+          <TouchableWithoutFeedback onPress={() => setTooltipData(null)}>
+            <View
+              onLayout={(event: LayoutChangeEvent) =>
+                setCardWidth(event.nativeEvent.layout.width)
               }
-            />
-          </ScrollView>
-        </View>
-        {/* Legend */}
-        <View
-          style={{
-            flexDirection: "row",
-            justifyContent: "center",
-            alignItems: "center",
-            marginTop: 25,
-            marginBottom: 15,
-          }}
-        >
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              marginHorizontal: 10,
-            }}
-          >
-            <View
               style={{
-                height: 12,
-                width: 12,
-                borderRadius: 6,
-                backgroundColor: "gray",
+                marginTop: 50,
+                width: screenWidth * 0.9, // dynamic 90% of the screen width
+                maxWidth: 600,
+                height: 480,
+                borderWidth: 1,
+                borderColor: "aqua",
+                borderRadius: 12,
+                backgroundColor: "#191919",
               }}
-            />
-            <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
-              Expected Hours
-            </Text>
-          </View>
-          <View
-            style={{
-              flexDirection: "row",
-              alignItems: "center",
-              marginHorizontal: 10,
-            }}
-          >
-            <View
-              style={{
-                height: 12,
-                width: 12,
-                borderRadius: 6,
-                backgroundColor: "aqua",
-              }}
-            />
-            <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
-              Over Hours
-            </Text>
-          </View>
-        </View>
-        {/* Tooltip */}
-        {tooltipData && (
-          <View
-            style={{
-              position: "absolute",
-              width: 120,
-              height: 90,
-              justifyContent: "space-around",
-              top: tooltipData.y,
-              left: tooltipData.x,
-              backgroundColor: "#333",
-              padding: 8,
-              borderRadius: 8,
-              elevation: 5,
-              shadowColor: "#000",
-              shadowOffset: { width: 0, height: 2 },
-              shadowOpacity: 0.5,
-              shadowRadius: 4,
-            }}
-          >
-            <Text style={{ fontSize: 14, color: "white", fontWeight: "bold" }}>
-              {`📅 ${formatTooltipDate(tooltipData.date, chartType)}`}
-            </Text>
-            <Text style={{ fontSize: 11, color: "white" }}>
-              {tooltipData.baseValue < tooltipData.plannedHours
-                ? `⏳ Duration: ${formatTime(tooltipData.baseValue)}h`
-                : `⏳ Expected: ${formatTime(tooltipData.baseValue)}h`}
-            </Text>
-            <Text style={{ fontSize: 11, color: "aqua" }}>
-              {`🚀 Over: ${formatTime(tooltipData.overHours || 0)}h`}
-            </Text>
-          </View>
-        )}
-      </View>
-    </TouchableWithoutFeedback>
+            >
+              {/* Titel */}
+              <Text
+                style={{
+                  fontFamily: "MPLUSLatin_Bold",
+                  fontSize: 25,
+                  color: "white",
+                  marginBottom: 80,
+                  marginTop: 25,
+                  textAlign: "center",
+                }}
+              >
+                Workhours Chart
+              </Text>
+              <ChartRadioButtons
+                chartType={chartType as "week" | "month" | "year"}
+                setChartType={(type) => {
+                  setChartType(type);
+                  setTooltipData(null); // close tooltip if chart type changes
+                }}
+              />
+              {/* Frame-Container with horizontal scrollbar */}
+              <View style={{ paddingHorizontal: cardPadding }}>
+                {/* Horizontal scrollbarer container for the BarChart */}
+                <ScrollView
+                  horizontal
+                  ref={scrollViewRef}
+                  onScroll={(e) => setScrollX(e.nativeEvent.contentOffset.x)}
+                  scrollEventThrottle={16}
+                  contentContainerStyle={{
+                    paddingRight: spacing + barWidth / 2,
+                  }}
+                >
+                  <BarChart
+                    width={computedChartWidth}
+                    yAxisLabelSuffix="h"
+                    stackData={stackData}
+                    maxValue={dynamicMaxValue} // regulate the size of the Y-Axis
+                    barWidth={barWidth}
+                    initialSpacing={initialSpacing}
+                    spacing={spacing}
+                    barBorderRadius={2.5}
+                    isAnimated
+                    yAxisColor={"white"}
+                    xAxisColor={"white"}
+                    rulesColor={"dimgray"} // color for the horizontal break lines
+                    xAxisLabelTextStyle={{ color: "white" }}
+                    yAxisTextStyle={{ color: "white" }}
+                    onPress={(item: any, index: number) =>
+                      handleBarPress(item, index)
+                    }
+                  />
+                </ScrollView>
+              </View>
+              {/* Legend */}
+              <View
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  marginTop: 25,
+                  marginBottom: 15,
+                }}
+              >
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    marginHorizontal: 10,
+                  }}
+                >
+                  <View
+                    style={{
+                      height: 12,
+                      width: 12,
+                      borderRadius: 6,
+                      backgroundColor: "gray",
+                    }}
+                  />
+                  <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
+                    Expected Hours
+                  </Text>
+                </View>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    marginHorizontal: 10,
+                  }}
+                >
+                  <View
+                    style={{
+                      height: 12,
+                      width: 12,
+                      borderRadius: 6,
+                      backgroundColor: "aqua",
+                    }}
+                  />
+                  <Text style={{ marginLeft: 5, fontSize: 14, color: "white" }}>
+                    Over Hours
+                  </Text>
+                </View>
+              </View>
+              {/* Tooltip */}
+              {tooltipData && (
+                <View
+                  style={{
+                    position: "absolute",
+                    width: 120,
+                    height: 90,
+                    justifyContent: "space-around",
+                    top: tooltipData.y,
+                    left: tooltipData.x,
+                    backgroundColor: "#333",
+                    padding: 8,
+                    borderRadius: 8,
+                    elevation: 5,
+                    shadowColor: "#000",
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowOpacity: 0.5,
+                    shadowRadius: 4,
+                  }}
+                >
+                  <Text
+                    style={{ fontSize: 14, color: "white", fontWeight: "bold" }}
+                  >
+                    {`📅 ${formatTooltipDate(tooltipData.date, chartType)}`}
+                  </Text>
+                  <Text style={{ fontSize: 11, color: "white" }}>
+                    {tooltipData.baseValue < tooltipData.plannedHours
+                      ? `⏳ Duration: ${formatTime(tooltipData.baseValue)}h`
+                      : `⏳ Expected: ${formatTime(tooltipData.baseValue)}h`}
+                  </Text>
+                  <Text style={{ fontSize: 11, color: "aqua" }}>
+                    {`🚀 Over: ${formatTime(tooltipData.overHours || 0)}h`}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </TouchableWithoutFeedback>
+        </CopilotTouchableView>
+      </CopilotStep>
+    </>
   );
 };
 

--- a/components/WorkHoursInput.tsx
+++ b/components/WorkHoursInput.tsx
@@ -16,6 +16,7 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { getAuth } from "firebase/auth";
 import { setDoc, doc, getDoc } from "firebase/firestore";
+import { CopilotStep, walkthroughable } from "react-native-copilot";
 
 import { FIREBASE_FIRESTORE } from "../firebaseConfig";
 import dayjs from "../dayjsConfig";
@@ -37,6 +38,9 @@ const WorkHoursInput = () => {
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
+
+  // modified walkthroughable for copilot tour
+  const CopilotTouchableView = walkthroughable(View);
 
   // hook to fetch the expected hours from Firestore by mount
   useEffect(() => {
@@ -130,156 +134,165 @@ const WorkHoursInput = () => {
   };
 
   return (
-    <View
-      style={{
-        width: screenWidth * 0.9, // use 90% of the screen width
-        maxWidth: 600,
-        alignItems: "center",
-        backgroundColor: "#191919",
-        borderRadius: 12,
-        padding: 20,
-        shadowColor: "#000",
-        shadowOpacity: 0.2,
-        shadowRadius: 10,
-        shadowOffset: { width: 0, height: 4 },
-        elevation: 4,
-        borderWidth: 1,
-        borderColor: "aqua",
-      }}
-    >
-      {/* title and subtitle */}
-      <Text
-        style={{
-          fontFamily: "MPLUSLatin_Bold",
-          fontSize: 25,
-          color: "white",
-          marginBottom: 60,
-          textAlign: "center",
-        }}
+    <>
+      {/* DetailsScreen copilot tour step 2 */}
+      <CopilotStep
+        name="WorkHoursCard"
+        order={1}
+        text="In this card you have to set the expected work hours for today and save them."
       >
-        Daily Workhours
-      </Text>
-
-      <Text
-        style={{
-          fontSize: 18,
-          fontFamily: "MPLUSLatin_ExtraLight",
-          color: "white",
-          textAlign: "center",
-          marginBottom: 10,
-        }}
-      >
-        "add your minimum working hours"
-      </Text>
-      <View
-        style={{
-          marginTop: 20,
-          width: "100%",
-          backgroundColor: "#191919",
-          alignItems: "center",
-        }}
-      >
-        {/* Text Input to enter the expected hours */}
-        <TextInput
-          placeholder="(e.g. 8)"
-          placeholderTextColor="grey"
-          value={tempExpectedHours}
-          keyboardType="numeric"
-          onChangeText={setTempExpectedHours}
+        <CopilotTouchableView
           style={{
-            marginBottom: 15,
-            width: screenWidth * 0.7, // dynamic with of 70%
-            maxWidth: 400,
-            borderColor: "aqua",
-            borderWidth: 1.5,
-            borderRadius: 12,
-            paddingLeft: 15,
-            paddingRight: 40,
-            paddingBottom: 5,
-            fontSize: 22,
-            height: 50,
-            color: "white",
-            fontWeight: "bold",
-            backgroundColor: "black",
-          }}
-        />
-      </View>
-      {/* Save Button */}
-      <TouchableOpacity
-        onPress={handleSaveMinHours}
-        style={{
-          width: screenWidth * 0.7, // dynamic with of 70%
-          maxWidth: 400,
-          borderRadius: 12,
-          overflow: "hidden",
-          borderWidth: 3,
-          borderColor: "white",
-          marginBottom: 25,
-        }}
-      >
-        <LinearGradient
-          colors={["#00FFFF", "#FFFFFF"]}
-          style={{
+            width: screenWidth * 0.9, // use 90% of the screen width
+            maxWidth: 600,
             alignItems: "center",
-            justifyContent: "center",
-            height: 45,
-            width: screenWidth * 0.7, // dynamic with of 70%
-            maxWidth: 400,
+            backgroundColor: "#191919",
+            borderRadius: 12,
+            padding: 20,
+            shadowColor: "#000",
+            shadowOpacity: 0.2,
+            shadowRadius: 10,
+            shadowOffset: { width: 0, height: 4 },
+            elevation: 4,
+            borderWidth: 1,
+            borderColor: "aqua",
           }}
         >
+          {/* title and subtitle */}
           <Text
             style={{
               fontFamily: "MPLUSLatin_Bold",
-              fontSize: 22,
-              color: "grey",
-              marginBottom: 5,
-              paddingRight: 10,
+              fontSize: 25,
+              color: "white",
+              marginBottom: 60,
+              textAlign: "center",
             }}
           >
-            Save
+            Daily Workhours
           </Text>
-        </LinearGradient>
-      </TouchableOpacity>
-      {/* Hourly Rate info container */}
-      <View
-        style={{
-          width: "100%",
-          height: 50,
-          alignItems: "flex-start",
-          justifyContent: "center",
-          paddingLeft: 10,
-          borderRadius: 10,
-          //shadow options for android
-          shadowColor: "#ffffff",
-          elevation: 2,
-          //shadow options for ios
-          shadowOffset: { width: 2, height: 2 },
-          shadowOpacity: 0.3,
-          shadowRadius: 3,
-          backgroundColor: "#191919",
-        }}
-      >
-        <Text
-          style={{
-            fontSize: 30,
-            fontWeight: "bold",
-            color: "white",
-            marginBottom: 5,
-          }}
-        >
+
           <Text
             style={{
-              color: "grey",
-              fontSize: 16,
-              fontFamily: "MPLUSLatin_Bold",
+              fontSize: 18,
+              fontFamily: "MPLUSLatin_ExtraLight",
+              color: "white",
+              textAlign: "center",
+              marginBottom: 10,
             }}
           >
-            Your expected WorkHours:{" "}
+            "add your minimum working hours"
           </Text>
-          {expectedHours || "Not set"}
-        </Text>
-      </View>
-    </View>
+          <View
+            style={{
+              marginTop: 20,
+              width: "100%",
+              backgroundColor: "#191919",
+              alignItems: "center",
+            }}
+          >
+            {/* Text Input to enter the expected hours */}
+            <TextInput
+              placeholder="(e.g. 8)"
+              placeholderTextColor="grey"
+              value={tempExpectedHours}
+              keyboardType="numeric"
+              onChangeText={setTempExpectedHours}
+              style={{
+                marginBottom: 15,
+                width: screenWidth * 0.7, // dynamic with of 70%
+                maxWidth: 400,
+                borderColor: "aqua",
+                borderWidth: 1.5,
+                borderRadius: 12,
+                paddingLeft: 15,
+                paddingRight: 40,
+                paddingBottom: 5,
+                fontSize: 22,
+                height: 50,
+                color: "white",
+                fontWeight: "bold",
+                backgroundColor: "black",
+              }}
+            />
+          </View>
+          {/* Save Button */}
+          <TouchableOpacity
+            onPress={handleSaveMinHours}
+            style={{
+              width: screenWidth * 0.7, // dynamic with of 70%
+              maxWidth: 400,
+              borderRadius: 12,
+              overflow: "hidden",
+              borderWidth: 3,
+              borderColor: "white",
+              marginBottom: 25,
+            }}
+          >
+            <LinearGradient
+              colors={["#00FFFF", "#FFFFFF"]}
+              style={{
+                alignItems: "center",
+                justifyContent: "center",
+                height: 45,
+                width: screenWidth * 0.7, // dynamic with of 70%
+                maxWidth: 400,
+              }}
+            >
+              <Text
+                style={{
+                  fontFamily: "MPLUSLatin_Bold",
+                  fontSize: 22,
+                  color: "grey",
+                  marginBottom: 5,
+                  paddingRight: 10,
+                }}
+              >
+                Save
+              </Text>
+            </LinearGradient>
+          </TouchableOpacity>
+          {/* Hourly Rate info container */}
+          <View
+            style={{
+              width: "100%",
+              height: 50,
+              alignItems: "flex-start",
+              justifyContent: "center",
+              paddingLeft: 10,
+              borderRadius: 10,
+              //shadow options for android
+              shadowColor: "#ffffff",
+              elevation: 2,
+              //shadow options for ios
+              shadowOffset: { width: 2, height: 2 },
+              shadowOpacity: 0.3,
+              shadowRadius: 3,
+              backgroundColor: "#191919",
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 30,
+                fontWeight: "bold",
+                color: "white",
+                marginBottom: 5,
+              }}
+            >
+              <Text
+                style={{
+                  color: "grey",
+                  fontSize: 16,
+                  fontFamily: "MPLUSLatin_Bold",
+                }}
+              >
+                Your expected WorkHours:{" "}
+              </Text>
+              {expectedHours || "Not set"}
+            </Text>
+          </View>
+        </CopilotTouchableView>
+      </CopilotStep>
+    </>
   );
 };
 

--- a/components/WorkHoursState.tsx
+++ b/components/WorkHoursState.tsx
@@ -43,6 +43,8 @@ interface WorkHoursStateProps {
   setSelectedBar: (bar: any) => void;
 }
 
+////////////////////////////////////////////////////////////////////////////
+
 // declare firebase auth
 const auth = getAuth();
 

--- a/components/WorkTimeTracker.tsx
+++ b/components/WorkTimeTracker.tsx
@@ -28,6 +28,7 @@ import {
 } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { CopilotStep, walkthroughable } from "react-native-copilot";
 
 import { FIREBASE_FIRESTORE } from "../firebaseConfig";
 import dayjs from "../dayjsConfig";
@@ -63,6 +64,9 @@ const WorkTimeTracker = () => {
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
+
+  // modified walkthroughable for copilot tour
+  const CopilotTouchableView = walkthroughable(View);
 
   // global WorkHoursState
   const {
@@ -136,7 +140,7 @@ const WorkTimeTracker = () => {
 
   // hook to update elapsed time
   useEffect(() => {
-    let timer: NodeJS.Timeout | null = null;
+    let timer: number | null = null;
     if (isWorking && startWorkTime) {
       const updateElapsedTime = () => {
         const currentSession = calculateElapsedTime(startWorkTime);
@@ -295,7 +299,7 @@ const WorkTimeTracker = () => {
         setStartWorkTime(newStartTime);
       } else {
         console.log("No Document found.");
-        alert("First add your expected hours.");
+        Alert.alert("First add your expected hours.");
         return;
       }
     } catch (error) {
@@ -378,7 +382,7 @@ const WorkTimeTracker = () => {
       );
       // condition to check if the snapshot is empty
       if (snapshot.empty) {
-        console.warn("No data found in Firestore.");
+        console.log("No data found.");
         return;
       }
       // initialize the data with the fetched data from firestore
@@ -413,125 +417,134 @@ const WorkTimeTracker = () => {
   }, []); // once when the component mounts
 
   return (
-    <View
-      style={{
-        width: screenWidth * 0.9, // use 90% of the screen width
-        maxWidth: 600,
-        alignItems: "center",
-        backgroundColor: "#191919",
-        borderRadius: 12,
-        padding: 20,
-        shadowColor: "#000",
-        shadowOpacity: 0.2,
-        shadowRadius: 10,
-        shadowOffset: { width: 0, height: 4 },
-        elevation: 4,
-        borderWidth: 1,
-        borderColor: "aqua",
-      }}
-    >
-      <Text
-        style={{
-          fontFamily: "MPLUSLatin_Bold",
-          fontSize: 25,
-          color: "white",
-          marginBottom: 60,
-          textAlign: "center",
-        }}
+    <>
+      {/* DetailsScreen copilot tour step 2 */}
+      <CopilotStep
+        name="WorkHoursTracker"
+        order={2}
+        text="In this area you can track your daily work hours."
       >
-        WorkTime Tracker
-      </Text>
-      {/* Start/Stop Button with  enable condition when user adds a expected hours */}
-      {!isWorking ? (
-        <TouchableOpacity
-          onPress={docExists ? handleStartWork : undefined}
-          disabled={!docExists}
+        <CopilotTouchableView
           style={{
-            width: screenWidth * 0.7, // dynamic with of 70%
-            maxWidth: 400,
+            width: screenWidth * 0.9, // use 90% of the screen width
+            maxWidth: 600,
+            alignItems: "center",
+            backgroundColor: "#191919",
             borderRadius: 12,
-            overflow: "hidden",
-            borderWidth: 3,
-            borderColor: "white",
-            marginBottom: 25,
-            opacity: docExists ? 1 : 0.5,
+            padding: 20,
+            shadowColor: "#000",
+            shadowOpacity: 0.2,
+            shadowRadius: 10,
+            shadowOffset: { width: 0, height: 4 },
+            elevation: 4,
+            borderWidth: 1,
+            borderColor: "aqua",
           }}
         >
-          <LinearGradient
-            colors={docExists ? ["#00FFFF", "#FFFFFF"] : ["#666", "#999"]}
+          <Text
             style={{
-              alignItems: "center",
-              justifyContent: "center",
-              height: 45,
-              width: screenWidth * 0.7, // dynamic with of 70%
-              maxWidth: 400,
+              fontFamily: "MPLUSLatin_Bold",
+              fontSize: 25,
+              color: "white",
+              marginBottom: 60,
+              textAlign: "center",
             }}
           >
-            <Text
+            WorkTime Tracker
+          </Text>
+          {/* Start/Stop Button with  enable condition when user adds a expected hours */}
+          {!isWorking ? (
+            <TouchableOpacity
+              onPress={docExists ? handleStartWork : undefined}
+              disabled={!docExists}
               style={{
-                fontFamily: "MPLUSLatin_Bold",
-                fontSize: 22,
-                color: docExists ? "grey" : "darkgrey",
-                marginBottom: 5,
-                paddingRight: 10,
+                width: screenWidth * 0.7, // dynamic with of 70%
+                maxWidth: 400,
+                borderRadius: 12,
+                overflow: "hidden",
+                borderWidth: 3,
+                borderColor: "white",
+                marginBottom: 25,
+                opacity: docExists ? 1 : 0.5,
               }}
             >
-              Start
-            </Text>
-          </LinearGradient>
-        </TouchableOpacity>
-      ) : (
-        <TouchableOpacity
-          onPress={handleStopWork}
-          style={{
-            width: 280,
-            borderRadius: 12,
-            overflow: "hidden",
-            borderWidth: 3,
-            borderColor: "white",
-            marginBottom: 25,
-          }}
-        >
-          <LinearGradient
-            colors={["#00FFFF", "#FFFFFF"]}
+              <LinearGradient
+                colors={docExists ? ["#00FFFF", "#FFFFFF"] : ["#666", "#999"]}
+                style={{
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: 45,
+                  width: screenWidth * 0.7, // dynamic with of 70%
+                  maxWidth: 400,
+                }}
+              >
+                <Text
+                  style={{
+                    fontFamily: "MPLUSLatin_Bold",
+                    fontSize: 22,
+                    color: docExists ? "grey" : "darkgrey",
+                    marginBottom: 5,
+                    paddingRight: 10,
+                  }}
+                >
+                  Start
+                </Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          ) : (
+            <TouchableOpacity
+              onPress={handleStopWork}
+              style={{
+                width: 280,
+                borderRadius: 12,
+                overflow: "hidden",
+                borderWidth: 3,
+                borderColor: "white",
+                marginBottom: 25,
+              }}
+            >
+              <LinearGradient
+                colors={["#00FFFF", "#FFFFFF"]}
+                style={{
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: 45,
+                  width: 280,
+                }}
+              >
+                <Text
+                  style={{
+                    fontFamily: "MPLUSLatin_Bold",
+                    fontSize: 22,
+                    color: "grey",
+                    marginBottom: 5,
+                    paddingRight: 10,
+                  }}
+                >
+                  Stop
+                </Text>
+              </LinearGradient>
+            </TouchableOpacity>
+          )}
+          {/* Tracking Animation */}
+          <View style={{ position: "relative", height: 20 }}>
+            {isWorking && <WorkTimeAnimation />}
+          </View>
+          {/* Tracking Time */}
+          <Text
             style={{
-              alignItems: "center",
-              justifyContent: "center",
-              height: 45,
-              width: 280,
+              fontWeight: "bold",
+              fontSize: 55,
+              color: isWorking ? "white" : "gray",
+              marginBottom: 5,
+              textAlign: "center",
             }}
           >
-            <Text
-              style={{
-                fontFamily: "MPLUSLatin_Bold",
-                fontSize: 22,
-                color: "grey",
-                marginBottom: 5,
-                paddingRight: 10,
-              }}
-            >
-              Stop
-            </Text>
-          </LinearGradient>
-        </TouchableOpacity>
-      )}
-      {/* Tracking Animation */}
-      <View style={{ position: "relative", height: 20 }}>
-        {isWorking && <WorkTimeAnimation />}
-      </View>
-      {/* Tracking Time */}
-      <Text
-        style={{
-          fontWeight: "bold",
-          fontSize: 55,
-          color: isWorking ? "white" : "gray",
-          marginBottom: 5,
-          textAlign: "center",
-        }}
-      >
-        {formatTime(elapsedTime)}
-      </Text>
-    </View>
+            {formatTime(elapsedTime)}
+          </Text>
+        </CopilotTouchableView>
+      </CopilotStep>
+    </>
   );
 };
 


### PR DESCRIPTION
## Titel  
Add a guided tour to the WorkHoursScreen

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [x] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR adds a guided copilot tour to the WorkHoursScreen. 
I created an SVGMaskPath component with Canvas to create a custom tour path window 
when the user reaches step 3 (the WorkHoursChart). 
The Canvas wraps the ChartCard to ensure the ChartCard is correctly focused.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Todo
- figure out how I can position the tooltip to 50px downwards , to become a better position (no documentations in the library)


