### PR TITLE
Fix  copilot tour after registration

### DIFF
--- a/Screens/LoginScreen.tsx
+++ b/Screens/LoginScreen.tsx
@@ -24,7 +24,6 @@ import {
   createUserWithEmailAndPassword,
   Auth,
 } from "firebase/auth";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { setDoc, doc, getDoc } from "firebase/firestore";
 import {
   ALERT_TYPE,
@@ -63,6 +62,8 @@ const LoginScreen: React.FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [secureTextEntry, setSecureTextEntry] = useState(true);
+
+  // state to handle the loading animation
   const [loading, setLoading] = useState<boolean>(false);
 
   // declaire the firebase authentication
@@ -147,15 +148,13 @@ const LoginScreen: React.FC = () => {
         firstLogin: true,
       });
 
-      // important: remove the tour flag, so that the tour is displayed on the next login
-      //await AsyncStorage.removeItem("hasSeenTour");
-      await AsyncStorage.multiRemove([
-        "hasSeenTour",
-        "hasSeenHomeTour",
-        "hasSeenDetailsTour",
-        "hasSeenWorkHoursTour",
-        "hasSeenVacationTour",
-      ]);
+      await setDoc(doc(FIREBASE_FIRESTORE, "Users", response.user.uid), {
+        hasSeenHomeTour: false,
+        hasSeenDetailsTour: false,
+        hasSeenVacationTour: false,
+        hasSeenWorkHoursTour: false,
+        firstLogin: true,
+      });
 
       // call the push token
       const token = await NotificationManager.registerForPushNotifications();
@@ -164,7 +163,7 @@ const LoginScreen: React.FC = () => {
         return;
       }
 
-      console.log("Expo Push Token:", token);
+      // console.log("Expo Push Token:", token);
 
       // save the push token to the firestore
       await NotificationManager.savePushTokenToDatabase(
@@ -197,7 +196,7 @@ const LoginScreen: React.FC = () => {
     try {
       const userRef = doc(FIREBASE_FIRESTORE, "Users", userId);
       await setDoc(userRef, userData, { merge: true });
-      console.log("User document created successfully");
+      // console.log("User document created successfully");
     } catch (error) {
       console.error("Error creating user document:", error);
     }

--- a/components/CustomCalendar.tsx
+++ b/components/CustomCalendar.tsx
@@ -31,6 +31,10 @@ export interface CustomCalendarRef {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const CustomCalendar = forwardRef<CustomCalendarRef, CustomCalendarProps>(
   (_, ref) => {
     // initialize the useCalendarStore and setCurrentMonth
@@ -63,8 +67,6 @@ const CustomCalendar = forwardRef<CustomCalendarRef, CustomCalendarProps>(
         setCurrentMonth(today); // set the calendar to the current month
       },
     }));
-    // modified walkthroughable for copilot tour
-    const CopilotTouchableView = walkthroughable(View);
 
     return (
       <>

--- a/components/DetailsProjectCard.tsx
+++ b/components/DetailsProjectCard.tsx
@@ -24,13 +24,14 @@ interface DetailsProjectCardProps {
 }
 
 //////////////////////////////////////////////////////////////////////////////////
+
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const DetailsProjectCard: React.FC<DetailsProjectCardProps> = () => {
   // route params
   const route = useRoute<DetailsProjectRouteProps>();
   const { projectName } = route.params;
-
-  // modified walkthroughable for copilot tour
-  const CopilotTouchableView = walkthroughable(View);
 
   return (
     <View>

--- a/components/EarningsCalculatorCard.tsx
+++ b/components/EarningsCalculatorCard.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-native";
 import React, { useEffect, useState } from "react";
 import { doc, getDoc } from "firebase/firestore";
-import { useRoute, RouteProp, useNavigation } from "@react-navigation/native";
+import { RouteProp, useNavigation } from "@react-navigation/native";
 import { LinearGradient } from "expo-linear-gradient";
 import { Alert } from "react-native";
 import { CopilotStep, walkthroughable } from "react-native-copilot";
@@ -30,14 +30,12 @@ type RootStackParamList = {
   Details: { projectId: string };
 };
 
-type EarningsCalculatorRouteProp = RouteProp<RootStackParamList, "Details">;
 export type EarningsCalculatorCardProp = RouteProp<
   RootStackParamList,
   "Details"
 >;
 
 interface EarningsCalculatorCardProps {
-  route: EarningsCalculatorRouteProp;
   projectId: string;
 }
 
@@ -46,17 +44,14 @@ interface EarningsCalculatorCardProps {
 // modified walkthroughable for copilot tour
 const CopilotWalkthroughView = walkthroughable(View);
 
-const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = () => {
+const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
+  projectId,
+}) => {
   // navigation
-  const route = useRoute<EarningsCalculatorRouteProp>();
   const navigation = useNavigation();
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
-
-  // route params
-  const { projectId } = route.params;
-  // console.log("route.params:", route.params);
 
   // console.log("EarningsCalculatorCard - projectId:", projectId);
 

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -20,16 +20,19 @@ interface Note {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
+
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const NoteList: React.FC<{ projectId: string }> = ({ projectId }) => {
   // note state
   const [notes, setNotes] = useState<Note[]>([]);
+
   // error handling stae
   const [error, setError] = useState<Error | null>(null);
+
   // loading state if backend isn´t ready
   const [loading, setLoading] = useState<boolean>(true);
-
-  // modified walkthroughable for copilot tour
-  const CopilotTouchableView = walkthroughable(View);
 
   // hook to fetch the notes from Firestore with snapshot
   useEffect(() => {

--- a/components/TimeTrackerCard.tsx
+++ b/components/TimeTrackerCard.tsx
@@ -43,12 +43,13 @@ interface TimeTrackingCardsProps {
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// modified walkthroughable for copilot tour
+const CopilotWalkthroughView = walkthroughable(View);
+
 const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   // initialize the routing
   const route = useRoute<TimeTrackerRouteProp>();
   const { projectId } = route.params;
-  // modified walkthroughable for copilot tour
-  const CopilotWalkthroughView = walkthroughable(View);
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
@@ -168,6 +169,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   const [delayedElapsedTime, setDelayedElapsedTime] = useState<number | null>(
     null
   );
+
   // function to handle app state changes if app is in background or foreground
   useEffect(() => {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
@@ -184,7 +186,6 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
           const now = new Date().getTime();
           if (!isNaN(lastTimeMs) && lastTimeMs < now) {
             const elapsedTime = (now - lastTimeMs) / 1000;
-
             // safe the elapsed time to the state
             setDelayedElapsedTime(elapsedTime);
           }

--- a/components/VacationForm.tsx
+++ b/components/VacationForm.tsx
@@ -19,10 +19,14 @@ import { useCalendarStore } from "../components/CalendarState";
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const VacationForm = () => {
   // initial start and end dates states
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
+
   // states to open the date pickers and show the selected dates
   const [tempStartDate, setTempStartDate] = useState<string | null>(null);
   const [tempEndDate, setTempEndDate] = useState<string | null>(null);
@@ -41,7 +45,6 @@ const VacationForm = () => {
         console.error("No user logged in");
         return;
       }
-
       // reduce markedDates to remove `customStyles` property
       const filteredMarkedDates = Object.keys(markedDates).reduce(
         (acc, date) => {
@@ -51,7 +54,6 @@ const VacationForm = () => {
         },
         {} as { [key: string]: any }
       );
-
       const vacationsCollection = collection(
         FIREBASE_FIRESTORE,
         "Users",
@@ -60,10 +62,8 @@ const VacationForm = () => {
         "AczkjyWoOxdPAIRVxjy3",
         "Vacations"
       );
-
       // conducted by sorting the keys of `markedDates`
       const startDate = Object.keys(filteredMarkedDates).sort()[0];
-
       // create new document in `Vacations` collection
       await addDoc(vacationsCollection, {
         uid: user.uid,
@@ -71,7 +71,6 @@ const VacationForm = () => {
         markedDates: filteredMarkedDates,
         createdAt: serverTimestamp(),
       });
-
       resetMarkedDates(); // reset marked dates after saving
     } catch (error) {
       console.error("Error saving vacation:", error);
@@ -84,7 +83,6 @@ const VacationForm = () => {
       console.error("No data to save in markedDates");
       return;
     }
-
     await handleSaveVacation();
   };
 
@@ -105,9 +103,6 @@ const VacationForm = () => {
       setTempEndDate(null);
     };
   }, []);
-
-  // modified walkthroughable for copilot tour
-  const CopilotTouchableView = walkthroughable(View);
 
   return (
     <ScrollView>
@@ -191,7 +186,6 @@ const VacationForm = () => {
                   </Text>
                 </View>
               </TouchableOpacity>
-
               {/* End Date Button */}
               <TouchableOpacity
                 onPress={() => {
@@ -204,7 +198,6 @@ const VacationForm = () => {
                     ]);
                     return;
                   }
-
                   setTempEndDate(new Date().toISOString().split("T")[0]);
                 }}
                 style={{
@@ -279,7 +272,6 @@ const VacationForm = () => {
               }}
             />
           )}
-
           {tempEndDate !== null && (
             <DateTimePicker
               value={tempEndDate ? new Date(tempEndDate) : new Date()}
@@ -304,7 +296,6 @@ const VacationForm = () => {
               }}
             />
           )}
-
           <View
             style={{
               height: 80,
@@ -352,7 +343,6 @@ const VacationForm = () => {
                 </Text>
               </LinearGradient>
             </TouchableOpacity>
-
             {/* Cancel Button */}
             <TouchableOpacity
               style={{

--- a/components/VacationList.tsx
+++ b/components/VacationList.tsx
@@ -28,6 +28,9 @@ import VacationRemindModal from "../components/VacationRemindModal";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const VacationList = () => {
   //set state for vacations
   const [vacations, setVacations] = useState<
@@ -81,15 +84,12 @@ const VacationList = () => {
         const markedDatesArray = data.markedDates
           ? Object.keys(data.markedDates)
           : [];
-
         // console.log("Converted markedDates:", markedDatesArray);
-
         return {
           id: doc.id,
           markedDates: markedDatesArray,
         };
       });
-
       // sort the vacations by the first marked date
       vacationsData.sort((a, b) => {
         if (a.markedDates.length === 0 || b.markedDates.length === 0) return 0;
@@ -98,11 +98,9 @@ const VacationList = () => {
           new Date(b.markedDates[0]).getTime()
         );
       });
-
       // console.log("Vacations Data:", vacationsData);
       setVacations(vacationsData);
     });
-
     return () => unsubscribe();
   }, [user]);
 
@@ -142,13 +140,10 @@ const VacationList = () => {
                 });
               }
             }
-
             // delete the vacation
             batch.delete(vacationDoc);
-
             // commit the batch to the database
             await batch.commit();
-
             // console.log(`Vacation ${vacationId} was deleted.`);
           } catch (error) {
             console.error("Error deleting vacation:", error);
@@ -164,9 +159,6 @@ const VacationList = () => {
     setSelectedVacationId(id);
     setReminderModalVisible(true);
   };
-
-  // modified walkthroughable for copilot tour
-  const CopilotTouchableView = walkthroughable(View);
 
   return (
     <>
@@ -247,7 +239,6 @@ const VacationList = () => {
                   const sortedDates = item.markedDates
                     .map((date) => {
                       const [year, month, day] = date.split("-");
-
                       // parseInt is used to convert the string to a number to sort the dates list
                       return {
                         formatted: `${parseInt(day, 10)}.${parseInt(month, 10)}.${year}`,
@@ -261,7 +252,6 @@ const VacationList = () => {
                     .sort(
                       (a, b) => a.timestamp.getTime() - b.timestamp.getTime()
                     ); // sort by timestamp
-
                   // extract the first and last date to show a range in the UI
                   const displayRange =
                     sortedDates.length > 1

--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -24,11 +24,16 @@ import { formatTime } from "../components/WorkTimeCalc";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// modified walkthroughable for copilot tour
+const CopilotWalkthroughView = walkthroughable(View);
+
 const WorkHoursChart = () => {
   // get the data from the WorkHoursState
   const { data } = WorkHoursState();
+
   // initialstate for the chart type
   const [chartType, setChartType] = useState("week");
+
   // state and types for the tooltip
   const [tooltipData, setTooltipData] = useState<{
     date: string;
@@ -39,8 +44,10 @@ const WorkHoursChart = () => {
     x: number;
     y: number;
   } | null>(null);
+
   // ref for the scrollview
   const scrollViewRef = useRef<ScrollView>(null);
+
   // state for the card width
   const [cardWidth, setCardWidth] = useState<number>(0);
 
@@ -49,6 +56,7 @@ const WorkHoursChart = () => {
 
   // card padding in px to calculate the inner width for the frame
   const cardPadding = 16;
+
   // state for the scrollX to save the tooltip position in the chart
   const [scrollX, setScrollX] = useState(0);
 
@@ -270,9 +278,6 @@ const WorkHoursChart = () => {
   };
 
   const dynamicMaxValue = getDynamicMaxValue();
-
-  // modified walkthroughable for copilot tour
-  const CopilotWalkthroughView = walkthroughable(View);
 
   return (
     <>

--- a/components/WorkTimeTracker.tsx
+++ b/components/WorkTimeTracker.tsx
@@ -47,26 +47,31 @@ interface DataPoint {
 
 ///////////////////////////////////////////////////////////////////////////////////
 
+// modified walkthroughable for copilot tour
+const CopilotTouchableView = walkthroughable(View);
+
 const WorkTimeTracker = () => {
   // state to store the user's time zone
   const [userTimeZone, setUserTimeZone] = useState<string>(dayjs.tz.guess());
+
   // local state for accumulated duration (in hours)
   const [accumulatedDuration, setAccumulatedDuration] = useState(0);
+
   // new trigger to reload the chart after stop
   // it is needed because the chart is not updated after stop the timer without reload
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+
   // state to handle the app state
   const [appState, setAppState] = useState(AppState.currentState);
+
   // reference to the previous app state
   const prevAppStateRef = useRef<AppStateStatus>(AppState.currentState);
+
   // state to get the work day from firestore to update the state wich is needed to enable the timer start button
   const [workDay, setWorkDay] = useState("");
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
-
-  // modified walkthroughable for copilot tour
-  const CopilotTouchableView = walkthroughable(View);
 
   // global WorkHoursState
   const {
@@ -161,7 +166,6 @@ const WorkTimeTracker = () => {
 
   // hook to update the app state if the app is in the foreground or background
   useEffect(() => {
-    // function to load the elapsedTime from AsyncStorage
     const loadElapsedTime = async () => {
       const storedElapsedTime = await AsyncStorage.getItem("elapsedTime");
       if (storedElapsedTime) {

--- a/components/services/copilotTour/TourCard.tsx
+++ b/components/services/copilotTour/TourCard.tsx
@@ -74,7 +74,7 @@ const TourButton: React.FC<TourButtonProps> = ({
           setShowTourCard(false);
         }
       } catch (error) {
-        console.log("Fehler beim Laden des Tour-Status aus Firestore:", error);
+        console.log("Error checking Firestore status:", error);
       }
     };
 
@@ -144,7 +144,7 @@ const TourButton: React.FC<TourButtonProps> = ({
   // function to skip the tour and set the tour status to true
   const handleSkipTour = async () => {
     try {
-      // set teh status to true in Firestore to show that the tour has been seen
+      // set the status to true in Firestore to show that the tour has been seen
       await updateFireStoreTourStatus(userId, true, storageKey);
       setShowTourCard(false);
       Alert.alert("Skip Tour", "You can start the tour later in the menu.");


### PR DESCRIPTION
## Titel  
Fix the Copilot state if user has seen the tour

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR adds: 
- the Copilot tour is only visible if user hasn´t seen the tour
- refactoring the Copilot hasSeenTour state from AsyncStorage to Firestore snapshot to prevent the rerendering if user uses a new device
- refactoring the DetailsScreen routing type structure
-  delete Firestore data with a batch collection if user deletes the account (not final)

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings
