### PR TITLE
Feature  deactivate the splashscreen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@
 
 /////////////////////////////////////////////////////////////////////////////
 
-import { Text, TouchableOpacity, View, Alert, Dimensions } from "react-native";
+import { Text, TouchableOpacity, View, Alert } from "react-native";
 import React, { useEffect, useState } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "react-native";
@@ -25,6 +25,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "react-native-gesture-handler";
 import "react-native-reanimated";
+import * as SplashScreen from "expo-splash-screen";
 import "text-encoding-polyfill"; //bugfix: for delete project with notes
 
 import LoginScreen from "./Screens/LoginScreen";
@@ -181,6 +182,9 @@ const CustomDrawerLabel: React.FC<CustomDrawerLabelProps> = ({
   </Text>
 );
 
+// disable splashscreen
+SplashScreen.preventAutoHideAsync();
+
 // drawer navigation for the app
 const App = () => {
   // statusbar content color
@@ -188,7 +192,14 @@ const App = () => {
     StatusBar.setBarStyle("light-content");
   }, 1000);
 
-  const { height } = Dimensions.get("window");
+  // hide splashscreen
+  useEffect(() => {
+    const hide = async () => {
+      // optional kannst du hier auf Fonts oder Daten warten
+      await SplashScreen.hideAsync();
+    };
+    hide();
+  }, []);
 
   // function for googe-fonts implemantation
   const [fontsLoaded] = useFonts({

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
     "splash": {
-      "resizeMode": "cover",
+      "resizeMode": "contain",
       "backgroundColor": "#000000"
     },
     "updates": {
@@ -16,11 +16,19 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.yourcompany.yourapp"
+      "bundleIdentifier": "com.yourcompany.yourapp",
+      "splash": {
+        "resizeMode": "contain",
+        "backgroundColor": "#000000"
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/icon.png",
+        "backgroundColor": "#000000"
+      },
+      "splash": {
+        "resizeMode": "contain",
         "backgroundColor": "#000000"
       },
       "package": "com.ChronoCraft_Android",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "expo-module-scripts": "^3.4.2",
         "expo-notifications": "^0.27.8",
         "expo-permissions": "^14.4.0",
+        "expo-splash-screen": "^0.26.5",
         "expo-status-bar": "~1.11.1",
         "expo-task-manager": "~11.7.3",
         "firebase": "^11.1.0",
@@ -20945,6 +20946,18 @@
       "peer": true,
       "dependencies": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "0.26.5",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.26.5.tgz",
+      "integrity": "sha512-FyvA2EWDeQdC3zuoQdXV2VmSANiJzF0hmbtoEEyR6MXoHaYFvxxKyhBeAm61N8C9TtUijIcEgFM6XBCh0wTBVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "6.8.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-module-scripts": "^3.4.2",
     "expo-notifications": "^0.27.8",
     "expo-permissions": "^14.4.0",
+    "expo-splash-screen": "^0.26.5",
     "expo-status-bar": "~1.11.1",
     "expo-task-manager": "~11.7.3",
     "firebase": "^11.1.0",


### PR DESCRIPTION
## Titel  
Add a function to deactive the SplashScreen

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [ ] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR deactivates the SplashScreen in Android and IOS.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies
install expo-splash-screen@0.26.5