### PR TITLE
Fix  hard kill issue in details screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 import { Text, TouchableOpacity, View } from "react-native";
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
@@ -278,53 +278,6 @@ const App = () => {
 
     checkAsyncStorage();
   }, []);
-
-  // useEffect(() => {
-  //   if (!user) return;
-
-  //   const recoverTracking = async () => {
-  //     const keys = await AsyncStorage.getAllKeys();
-  //     const trackingKeys = keys.filter((k) =>
-  //       k.startsWith("trackingSnapshot_")
-  //     );
-
-  //     for (const key of trackingKeys) {
-  //       const json = await AsyncStorage.getItem(key);
-  //       if (!json) continue;
-
-  //       const snapshot = JSON.parse(json);
-  //       const projectId = key.replace("trackingSnapshot_", "");
-
-  //       if (snapshot.isTracking && snapshot.lastStartTime) {
-  //         const referenceStart = new Date(snapshot.lastStartTime).getTime();
-  //         const now = Date.now();
-  //         const elapsed = Math.max(0, (now - referenceStart) / 1000);
-  //         const newTime = snapshot.timer + elapsed;
-
-  //         console.log("✅ Wiederherstellung:", {
-  //           projectId,
-  //           elapsed,
-  //           newTime,
-  //         });
-
-  //         useStore.getState().setProjectData(projectId, {
-  //           timer: newTime,
-  //           isTracking: true,
-  //           hourlyRate: snapshot.hourlyRate,
-  //           lastStartTime: new Date(snapshot.lastStartTime),
-  //           originalStartTime: new Date(snapshot.originalStartTime),
-  //           totalEarnings: (newTime / 3600) * snapshot.hourlyRate,
-  //         });
-
-  //         await AsyncStorage.removeItem(key);
-  //       } else {
-  //         console.log(`❌ Ungültiger Snapshot für ${projectId}`);
-  //       }
-  //     }
-  //   };
-
-  //   recoverTracking();
-  // }, [user]);
 
   // hook to handle the notification initialization
   useEffect(() => {

--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 import { Text, TouchableOpacity, View } from "react-native";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { StatusBar } from "react-native";
 import { NavigationContainer } from "@react-navigation/native";
@@ -20,7 +20,7 @@ import {
   AntDesign,
 } from "@expo/vector-icons";
 import { useFonts } from "expo-font";
-import { User, onAuthStateChanged } from "firebase/auth";
+import { User, onAuthStateChanged, getAuth } from "firebase/auth";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import "react-native-gesture-handler";
@@ -29,6 +29,7 @@ import * as SplashScreen from "expo-splash-screen";
 import "text-encoding-polyfill"; //bugfix: for delete project with notes
 import { CopilotProvider } from "react-native-copilot";
 import { AccessibilityInfo } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 import LoginScreen from "./Screens/LoginScreen";
 import HomeScreen from "./Screens/HomeScreen";
@@ -263,6 +264,67 @@ const App = () => {
       setUser(user);
     });
   }, []);
+
+  useEffect(() => {
+    const checkAsyncStorage = async () => {
+      const allKeys = await AsyncStorage.getAllKeys();
+      // console.log("every key in AsyncStorage:", allKeys);
+
+      for (const key of allKeys) {
+        const item = await AsyncStorage.getItem(key);
+        // console.log(`${key}:`, item);
+      }
+    };
+
+    checkAsyncStorage();
+  }, []);
+
+  // useEffect(() => {
+  //   if (!user) return;
+
+  //   const recoverTracking = async () => {
+  //     const keys = await AsyncStorage.getAllKeys();
+  //     const trackingKeys = keys.filter((k) =>
+  //       k.startsWith("trackingSnapshot_")
+  //     );
+
+  //     for (const key of trackingKeys) {
+  //       const json = await AsyncStorage.getItem(key);
+  //       if (!json) continue;
+
+  //       const snapshot = JSON.parse(json);
+  //       const projectId = key.replace("trackingSnapshot_", "");
+
+  //       if (snapshot.isTracking && snapshot.lastStartTime) {
+  //         const referenceStart = new Date(snapshot.lastStartTime).getTime();
+  //         const now = Date.now();
+  //         const elapsed = Math.max(0, (now - referenceStart) / 1000);
+  //         const newTime = snapshot.timer + elapsed;
+
+  //         console.log("✅ Wiederherstellung:", {
+  //           projectId,
+  //           elapsed,
+  //           newTime,
+  //         });
+
+  //         useStore.getState().setProjectData(projectId, {
+  //           timer: newTime,
+  //           isTracking: true,
+  //           hourlyRate: snapshot.hourlyRate,
+  //           lastStartTime: new Date(snapshot.lastStartTime),
+  //           originalStartTime: new Date(snapshot.originalStartTime),
+  //           totalEarnings: (newTime / 3600) * snapshot.hourlyRate,
+  //         });
+
+  //         await AsyncStorage.removeItem(key);
+  //       } else {
+  //         console.log(`❌ Ungültiger Snapshot für ${projectId}`);
+  //       }
+  //     }
+  //   };
+
+  //   recoverTracking();
+  // }, [user]);
 
   // hook to handle the notification initialization
   useEffect(() => {

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -397,6 +397,7 @@ const HomeScreen: React.FC = () => {
 
   // scroll animation with parameters to handle the scroll animation
   const renderItem = ({ item, index }: { item: any; index: number }) => {
+    // Animation-Berechnungen
     const inputRange = [
       -1,
       0,
@@ -416,6 +417,22 @@ const HomeScreen: React.FC = () => {
       outputRange: [1, 1, 1, 0.5, 0],
       extrapolate: "clamp",
     });
+
+    // converte date to enable both unix timestamps and firebase timestamps
+    let dateObj: Date | null = null;
+    if (item.createdAt) {
+      if (item.createdAt instanceof Date) {
+        dateObj = item.createdAt;
+      } else if (
+        item.createdAt.toDate &&
+        typeof item.createdAt.toDate === "function"
+      ) {
+        dateObj = item.createdAt.toDate();
+      } else if (typeof item.createdAt === "number") {
+        // Fallback for Unix-Timestamps
+        dateObj = new Date(item.createdAt);
+      }
+    }
 
     // calculate the average item height to handle functionality of the scroll animation
     const mesureItemHeight = (event: LayoutChangeEvent) => {
@@ -459,7 +476,7 @@ const HomeScreen: React.FC = () => {
           <TouchableOpacity
             onPress={() => handleProjectPress(item.id as string, item.name)}
             accessibilityRole="button"
-            accessibilityLabel={`Project ${item.name}, created on ${dayjs(item.createdAt.toDate()).format("DD MMMM YYYY")}`}
+            accessibilityLabel={`Project ${item.name}, created on ${dateObj ? dayjs(dateObj).format("DD MMMM YYYY") : "unknown date"}`}
             accessibilityHint="Tap to view project details"
             style={{ alignItems: "center", justifyContent: "center", flex: 1 }}
           >
@@ -470,19 +487,31 @@ const HomeScreen: React.FC = () => {
               }}
             >
               {/* Section with date in the project container */}
-              {item.createdAt &&
-                typeof item.createdAt.toDate === "function" && (
-                  <Text
-                    style={{
-                      color: accessMode ? "white" : "grey",
-                      fontSize: accessMode ? 16 : 13,
-                      paddingLeft: 10,
-                      marginTop: 5,
-                    }}
-                  >
-                    {dayjs(item.createdAt.toDate()).format("DD.MM.YYYY")}
-                  </Text>
-                )}
+              {dateObj ? (
+                <Text
+                  style={{
+                    color: accessMode ? "white" : "grey",
+                    fontSize: accessMode ? 16 : 13,
+                    paddingLeft: 10,
+                    marginTop: 5,
+                  }}
+                >
+                  {dayjs(dateObj).format("DD.MM.YYYY")}
+                </Text>
+              ) : (
+                <Text
+                  style={{
+                    color: "gray",
+                    fontSize: 13,
+                    paddingLeft: 10,
+                    marginTop: 5,
+                    fontStyle: "italic",
+                  }}
+                >
+                  No date available
+                </Text>
+              )}
+
               {/* Project name in the project container */}
               <Text
                 style={{

--- a/components/ProgressCard.tsx
+++ b/components/ProgressCard.tsx
@@ -96,8 +96,8 @@ const ProgressCard: React.FC<ProgressCardProps> = React.memo(
     const progressRaw = useMemo(() => {
       return maxSeconds > 0 ? timer / maxSeconds : 0;
     }, [timer, maxSeconds]);
-    const progress = Math.min(progressRaw, 1); // 0 bis 1 → for Animated
-    const progressValue = Math.min(progressRaw * 100, 100); // 0 bis 100 → forCircularProgress
+    const progress = Math.min(progressRaw, 1); // 0 to 1 → for Animated
+    const progressValue = Math.min(progressRaw * 100, 100); // 0 to 100 → forCircularProgress
 
     // input state
     const [inputMaxWorkHours, setInputMaxWorkHours] = useState("");

--- a/components/TimeTrackingState.ts
+++ b/components/TimeTrackingState.ts
@@ -103,12 +103,19 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
 
   // function to fetch data from Firestore if user navigate to details screen
   setProjectData: (projectId, projectData) => {
-    set((state) => ({
-      projects: {
-        ...state.projects,
-        [projectId]: { ...state.projects[projectId], ...projectData },
-      },
-    }));
+    set((state) => {
+      const updatedProject = {
+        ...(state.projects[projectId] || {}),
+        ...projectData,
+      };
+
+      return {
+        projects: {
+          ...state.projects,
+          [projectId]: updatedProject,
+        },
+      };
+    });
   },
 
   // function to set the current project id
@@ -184,6 +191,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   startTimer: async (projectId: string) => {
     const state = get();
     const project = state.projects[projectId];
+
     // check if project is already being tracked
     if (project.isTracking) {
       console.warn("Project is already being tracked");


### PR DESCRIPTION
## Titel  
Fix hard kill issue in the DetailsScreen 

## Type of Changes 
- [x] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [x] 🎭 ui: Ui changes  

## Changes  
This PR ensures that the tracker is running after a hardkill. That means, timer, earnings and progress indicator will continue his work when the user enters the details screen by the project what was killed. 

How it works: Every 10 seconds will the value stored in AsyncStorage and if the app crashed the vaule will loaded from AsyncStorage and used inside the TimeTrackingCard by rendering. I fixed an timer performace issue with useMemo and addeting the formateTime function global. That prevents js-threat blockades. Now every seconds in the UI will changes fluently.

I also changed the UI inside the tracking info from "NaN" to "- - - " when no value is sattled. That ensures a more userfriendly (no technical) understanding, what is the current status of the informations.

And I blocked the play button if the timer is running to ensure user can only start the timer when it is not running.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

