### PR TITLE
fix: prevent WorkTimeTracker hardkill

### DIFF
--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -162,6 +162,8 @@ const WorkHoursChart = () => {
       return false;
     });
   };
+
+  // filter the data by chart type
   const filteredData = filterDataByChartType(data, chartType);
 
   // help function to formate the x-axis label in the different chart modes

--- a/components/WorkHoursInput.tsx
+++ b/components/WorkHoursInput.tsx
@@ -321,7 +321,7 @@ const WorkHoursInput = () => {
               >
                 Your expected WorkHours:{" "}
               </Text>
-              {expectedHours || "Not set"}
+              {expectedHours || "- - -"}
             </Text>
           </View>
         </CopilotWalktroughView>

--- a/components/WorkHoursState.tsx
+++ b/components/WorkHoursState.tsx
@@ -65,6 +65,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
     if (!user) return;
 
     try {
+      const today = new Date().toISOString().split("T")[0];
       const docRef = doc(
         FIREBASE_FIRESTORE,
         "Users",
@@ -72,19 +73,24 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
         "Services",
         "AczkjyWoOxdPAIRVxjy3",
         "WorkHours",
-        get().currentDocId || "defaultDocId"
+        today
       );
+
       const docSnap = await getDoc(docRef);
       if (docSnap.exists()) {
         const state = docSnap.data();
-        set({
-          elapsedTime: state.elapsedTime || 0,
-          isWorking: state.isWorking || false,
-          startWorkTime: state.startWorkTime || null,
-        });
+        const savedDate = state.lastUpdatedDate || "";
+
+        // set the state if the saved date is today
+        if (savedDate === today) {
+          set({
+            currentDocId: today,
+            lastUpdatedDate: today,
+          });
+        }
       }
     } catch (error) {
-      console.log("Error loading state from Firestore:", error);
+      console.error("Error loading state:", error);
     }
   },
 


### PR DESCRIPTION
## Titel  
Prevent hardkill in the WorkTimeTracker

## Type of Changes 
- [x] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR adds the feature to hold the tracking state if user kills the app, or the app will crashing. 
The state is stored with an interval in AsyncStorage and will restore if the user returned into the WorkHoursScreen.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings 