### PR TITLE
feat: allow reset when tracking is stopped with using a custom alert

### DIFF
--- a/components/TimeTrackerCard.tsx
+++ b/components/TimeTrackerCard.tsx
@@ -492,6 +492,20 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   // function to reset the timer
   const [resetting, setResetting] = useState(false);
   const handleReset = async () => {
+    const project = useStore.getState().projects[projectId];
+    // confirm reset
+    if (project.isTracking) {
+      // alert to inform the user what he has to do before pressing the reset button
+      useAlertStore
+        .getState()
+        .showAlert(
+          "Attention!",
+          "Please stop the project first before resetting it.",
+          [{ text: "OK", style: "default" }]
+        );
+      return;
+    }
+    // alert to ask the user if he really wants to reset the project
     useAlertStore
       .getState()
       .showAlert(


### PR DESCRIPTION
## Titel  
Condition to allew reset when tracking is stopped

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [ ] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR adds a condition with an alert that informs the user, that they must first stop tracking before resetting.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings