### PR TITLE
fix: display really worked time in the monthly chart

### DIFF
--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -197,9 +197,19 @@ const WorkHoursChart = () => {
       if (!monthlySums[key]) {
         monthlySums[key] = { expected: 0, over: 0, planned: 0 };
       }
-      monthlySums[key].expected += Number(item.expectedHours) || 0;
-      monthlySums[key].over += Number(item.overHours) || 0;
-      monthlySums[key].planned += Number(item.expectedHours) || 0;
+
+      const worked = Number(item.elapsedTime) || 0;
+      const planned = Number(item.expectedHours) || 0;
+
+      // worked-part, max. planed hours
+      const base = worked < planned ? worked : planned;
+
+      // Overhours only if more worked than planned
+      const extra = worked > planned ? worked - planned : 0;
+
+      monthlySums[key].expected += base; // really worked hours
+      monthlySums[key].over += extra; // really over hours
+      monthlySums[key].planned += planned; // planned hours
     });
     // map the monthly sums to the bar chart and format the x-axis labels
     stackData = Object.keys(monthlySums).map((key) => {


### PR DESCRIPTION
## Titel  
Fix: Display real worked time in monthly chart

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [ ] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
This PR changed the filteredData.forEacht mapping function, to display the really worked time in the monthly chart.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings