### PR TITLE
feat(sec): validate-VacationScreen-and-update-firestoreSchema-and-custom-function-wrapper

### DIFF
--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -69,7 +69,7 @@ import { useDotAnimation } from "../components/DotAnimation";
 import { sanitizeTitle } from "../components/InputSanitizers";
 import SortModal from "../components/SortModal";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
-import getValidatedDocs from "../validation/getDocsWrapper";
+import { getValidatedDocs } from "../validation/getDocsWrapper";
 import {
   FirestoreProjectSchema,
   FirestoreUserSchema,
@@ -83,6 +83,11 @@ type HomeScreenRouteProp = RouteProp<
 >;
 
 type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList>;
+
+interface Note {
+  content: string;
+  timestamp: Date;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -217,15 +222,16 @@ const HomeScreen: React.FC = () => {
         );
 
         // ensure createdAt is always set
-        const projectsWithFallback = validatedProjects.map((p) => ({
-          ...p,
-          createdAt: p.createdAt ?? new Date(),
-          notes: p.notes.map((n) => ({
-            ...n,
-            timestamp: n.timestamp ?? new Date(),
-          })),
-        }));
-
+        const projectsWithFallback = validatedProjects.map(
+          (p: FirestoreProject) => ({
+            ...p,
+            createdAt: p.createdAt ?? new Date(),
+            notes: p.notes.map((n: Note) => ({
+              ...n,
+              timestamp: n.timestamp ?? new Date(),
+            })),
+          })
+        );
         setProjects(projectsWithFallback);
       } catch (error) {
         console.error("Error fetching projects", error);

--- a/Screens/VacationScreen.tsx
+++ b/Screens/VacationScreen.tsx
@@ -23,6 +23,7 @@ import TourCard from "../components/services/copilotTour/TourCard";
 import { useCopilotOffset } from "../components/services/copilotTour/CopilotOffset";
 import CustomTooltip from "../components/services/copilotTour/CustomToolTip";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
+import { FirestoreUserSchema } from "../validation/firestoreSchemas";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -76,13 +77,22 @@ const VacationScreen: React.FC<VacationScreenRouteProps> = () => {
         const docSnap = await getDoc(docRef);
 
         if (docSnap.exists()) {
-          const data = docSnap.data();
-          setShowTourCard(data.hasSeenVacationTour === false);
+          const raw = docSnap.data();
+          // validate the user data
+          const parsed = FirestoreUserSchema.safeParse(raw);
+          if (!parsed.success) {
+            console.error(
+              "Invalid user data in fetchTourStatus:",
+              parsed.error
+            );
+            setShowTourCard(false);
+            return;
+          }
+          setShowTourCard(parsed.data.hasSeenVacationTour === false);
         } else {
           setShowTourCard(false);
         }
       };
-
       fetchTourStatus();
     }, [])
   );

--- a/validation/firestoreSchemas.ts
+++ b/validation/firestoreSchemas.ts
@@ -48,6 +48,7 @@ export const FirestoreUserSchema = z.object({
   totpEnabled: z.boolean().optional().default(false),
   totpSecret: z.string().nullable().optional(),
   hasSeenHomeTour: z.boolean().optional().default(false),
+  hasSeenVacationTour: z.boolean().optional().default(false),
   createdAt: timestampToDateOptional, // optional, converted to Date when present
 });
 export type FirestoreUser = z.infer<typeof FirestoreUserSchema>;


### PR DESCRIPTION
## Titel  
Validate Firestore data with Zod and improve Tour handling in VacationScreen

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
- Added `hasSeenVacationTour` validation in `VacationScreen` using `FirestoreUserSchema`.  
- Updated `HomeScreen` project loading to use `getValidatedDocs` and ensure `createdAt` / `notes.timestamp` always have Date fallback.  
- Added `Note` interface for type safety in `HomeScreen`.  
- Updated `getDocsWrapper` to include `getValidatedDoc` for single-document validation.  
- Extended `FirestoreUserSchema` to include `hasSeenVacationTour` with defaults.  
- Replaced all raw Firestore data reads with Zod validation to prevent missing or manipulated fields.  
- Fixed TypeScript type errors related to implicit `any` and missing types after wrapper refactor.  

## Tests  
- [x] ✅ Changes are tested (Jest tests for `fetchTourStatus` and HomeScreen project mapping)  
- [ ] 🚫 No tests necessary 

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings