### PR TITLE
Security/validate vacation form with zod

### DIFF
--- a/__tests__/vacationSchemas.test.ts
+++ b/__tests__/vacationSchemas.test.ts
@@ -1,0 +1,74 @@
+//////////////////////////////vacationSchemas.test.ts////////////////////////////
+
+// This file is used to test the vacation schemas with unit tests
+// It tests the VacationInputSchema and FirestoreVacationSchema
+
+///////////////////////////////////////////////////////////////////////////////
+
+import {
+  VacationInputSchema,
+  FirestoreVacationSchema,
+} from "../validation/vacationSchemas";
+
+///////////////////////////////////////////////////////////////////////////////
+
+describe("Vacation Schemas", () => {
+  it("accepts valid vacation input", () => {
+    const valid = {
+      startDate: "2025-09-23",
+      markedDates: {
+        "2025-09-23": { selected: true },
+        "2025-09-24": { selected: true, color: "blue" },
+      },
+    };
+    const r = VacationInputSchema.safeParse(valid);
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects invalid date keys in markedDates", () => {
+    const invalid = {
+      startDate: "2025-09-23",
+      markedDates: {
+        "23-09-2025": { selected: true }, // wrong format
+      },
+    };
+    expect(VacationInputSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects missing startDate", () => {
+    const invalid = {
+      markedDates: {
+        "2025-09-23": { selected: true },
+      },
+    };
+    expect(VacationInputSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it("accepts Firestore vacation with Timestamp-like createdAt", () => {
+    // mock Firestore Timestamp object with toDate()
+    const mockTimestamp = { toDate: () => new Date("2025-09-23T00:00:00Z") };
+    const doc = {
+      id: "abc",
+      uid: "user1",
+      startDate: "2025-09-23",
+      markedDates: { "2025-09-23": { selected: true } },
+      createdAt: mockTimestamp,
+    };
+
+    const r = FirestoreVacationSchema.safeParse(doc);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.createdAt instanceof Date).toBe(true);
+    }
+  });
+
+  it("rejects Firestore vacation with invalid startDate format", () => {
+    const doc = {
+      id: "abc",
+      uid: "user1",
+      startDate: "23.09.2025",
+      markedDates: { "2025-09-23": { selected: true } },
+    };
+    expect(FirestoreVacationSchema.safeParse(doc).success).toBe(false);
+  });
+});

--- a/validation/vacationSchemas.ts
+++ b/validation/vacationSchemas.ts
@@ -1,0 +1,66 @@
+//////////////////////////////vacationSchemas.ts////////////////////////////
+
+// This file validates user data coming from the VacationForm
+
+///////////////////////////////////////////////////////////////////////////
+
+import { z } from "zod";
+
+///////////////////////////////////////////////////////////////////////////
+
+/**
+ * MarkedDate: flexible object for each date entry in the calendar.
+ * We keep it permissive (only expected keys validated) but strict on types.
+ * Use .catchall(z.any()) to allow extra keys (replacement for .passthrough()).
+ */
+export const MarkedDateEntrySchema = z
+  .object({
+    selected: z.boolean().optional(),
+    color: z.string().optional(),
+    textColor: z.string().optional(),
+    // additional keys are allowed and will be accepted as 'any'
+  })
+  .catchall(z.any());
+
+/**
+ * MarkedDates: record where keys are ISO date strings (YYYY-MM-DD)
+ * and values must match MarkedDateEntrySchema
+ */
+export const MarkedDatesSchema = z.record(
+  z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "invalid date key format"),
+  MarkedDateEntrySchema
+);
+
+/**
+ * Schema for the input coming from the VacationForm (validated before addDoc)
+ * - startDate: first day (string in YYYY-MM-DD)
+ * - markedDates: map validated by MarkedDatesSchema
+ */
+export const VacationInputSchema = z.object({
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "startDate must be YYYY-MM-DD"),
+  markedDates: MarkedDatesSchema,
+});
+export type VacationInput = z.infer<typeof VacationInputSchema>;
+
+// Schema for Firestore-stored Vacation document
+const timestampToDateOptional = z.preprocess((val) => {
+  if (val == null) return undefined;
+  if ((val as any)?.toDate && typeof (val as any).toDate === "function")
+    return (val as any).toDate();
+  if (val instanceof Date) return val;
+  if (typeof val === "number") return new Date(val);
+  return undefined;
+}, z.date().optional());
+
+export const FirestoreVacationSchema = z.object({
+  id: z.string().optional(),
+  uid: z.string(),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "startDate must be YYYY-MM-DD"),
+  markedDates: MarkedDatesSchema,
+  createdAt: timestampToDateOptional,
+});
+export type FirestoreVacation = z.infer<typeof FirestoreVacationSchema>;


### PR DESCRIPTION
## Titel  
Add Zod validation and tests for VacationForm and Firestore Vacation documents

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [x] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
- Added Zod validation for VacationForm input (`VacationInputSchema`) to ensure `startDate` and `markedDates` are properly formatted before saving to Firestore.  
- Updated FirestoreVacationSchema (`FirestoreVacationSchema`) to validate Firestore-stored vacation documents and convert Firestore timestamps to JS `Date`.  
- Integrated Zod validation inside `VacationForm` before calling `addDoc`. Invalid input triggers an alert and prevents saving.  
- Removed `accessMode` from `VacationForm` since it was unused.  
- Added Jest unit tests for:
  - `VacationInputSchema` (valid and invalid input)
  - `FirestoreVacationSchema` (valid documents and invalid startDate formats)  
- Updated helper types and schemas to use `.catchall(z.any())` instead of deprecated `.passthrough()` for flexibility with extra keys in `markedDates`.  

## Tests  
- [x] ✅ VacationForm input validation tested via Jest (`__tests__/vacationSchemas.test.ts`)  
- [x] ✅ FirestoreVacationSchema tested with mock Timestamp objects  
- [ ] 🚫 No tests necessary  

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings