### PR TITLE
Security/validate and test vacation list

### DIFF
--- a/__tests__/getDocsWrapper.vacation.test.ts
+++ b/__tests__/getDocsWrapper.vacation.test.ts
@@ -1,0 +1,65 @@
+///////////////////getDocsWrapper.vacation.test.ts/////////////////////////////
+
+// This file is used to test the getDocsWrapper with a mocked snapshot
+// to test the vacation data which comes from firestore inside the VacationList
+
+///////////////////////////////////////////////////////////////////////////////
+
+import { getValidatedDocs } from "../validation/getDocsWrapper";
+import { FirestoreVacationSchema } from "../validation/vacationSchemas";
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Mock firebase/firestore BEFORE importing modules that import it
+jest.mock("firebase/firestore", () => ({
+  getDocs: jest.fn(), // if the wrapper uses getDocs
+  collection: jest.fn(),
+  getDoc: jest.fn(),
+  doc: jest.fn(),
+  onSnapshot: jest.fn(),
+}));
+
+describe("getValidatedDocs with FirestoreVacationSchema", () => {
+  it("returns only valid vacation docs", async () => {
+    // spy console.error
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    // generate a mock snapshot
+    const mockSnapshot = {
+      docs: [
+        {
+          id: "abc",
+          data: () => ({
+            uid: "user1",
+            startDate: "2025-09-23",
+            markedDates: { "2025-09-23": { selected: true } },
+            createdAt: new Date("2025-09-23"),
+            reminderDuration: 10,
+          }),
+        },
+        {
+          id: "invalid",
+          data: () => ({
+            uid: "user2",
+            startDate: "23.09.2025", // wrong date format -> invalid
+            markedDates: {},
+          }),
+        },
+      ],
+    };
+
+    // Call: The wrapper function can either expect a CollectionRef or a Snapshot.
+    const result = await getValidatedDocs(
+      mockSnapshot as any,
+      FirestoreVacationSchema as any
+    );
+    // assert a console.error happened for the invalid doc
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toEqual(
+      expect.stringContaining("Invalid Firestore document")
+    );
+    // restore
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: "jest-expo",
   setupFilesAfterEnv: ["@testing-library/jest-native/extend-expect"],
+  testEnvironment: "node",
 };

--- a/validation/getDocsWrapper.ts
+++ b/validation/getDocsWrapper.ts
@@ -9,32 +9,97 @@ import {
   getDocs,
   DocumentReference,
   getDoc,
+  QuerySnapshot,
+  DocumentData,
 } from "firebase/firestore";
 import { z } from "zod";
 
 ///////////////////////////////////////////////////////////////////////////
 
-// validate all documents in a collection
+// This function normalizes a Firestore doc-like object so we can safely call schema on it.
+// Accepts both real firestore docs (doc.data() is function) and test-mocks
+// where data may be an object.
+
+function normalizeDocRaw(doc: any) {
+  const rawData = typeof doc.data === "function" ? doc.data() : doc.data;
+  return { id: doc.id, ...rawData };
+}
+
+// Validate a collection of documents (firbase snapshots)
+// Accepts either a CollectionReference (will call getDocs) OR a snapshot-like object
+// (QuerySnapshot<DocumentData> or { docs: any[] } used in tests).
+// Returns a Promise<T[]> with only the successfully validated documents.
+
 export async function getValidatedDocs<T>(
-  collectionRef: CollectionReference,
+  collectionOrSnapshot:
+    | CollectionReference
+    | QuerySnapshot<DocumentData>
+    | { docs: any[] },
   schema: z.ZodSchema<T>
 ): Promise<T[]> {
-  const snapshot = await getDocs(collectionRef);
+  // determine whether we received a snapshot-like object or a collectionRef
+  let snapshot: QuerySnapshot<DocumentData> | { docs: any[] };
+
+  if (collectionOrSnapshot && (collectionOrSnapshot as any).docs) {
+    // snapshot-like passed directly (tests or onSnapshot callback)
+    snapshot = collectionOrSnapshot as { docs: any[] };
+  } else {
+    // assume CollectionReference
+    snapshot = await getDocs(collectionOrSnapshot as CollectionReference);
+  }
+
   const validated: T[] = [];
 
-  snapshot.docs.forEach((doc) => {
-    const result = schema.safeParse({ id: doc.id, ...doc.data() });
-    if (result.success) {
-      validated.push(result.data);
-    } else {
-      console.error("Invalid Firestore document:", doc.id, result.error);
+  for (const doc of (snapshot as any).docs) {
+    try {
+      const raw = normalizeDocRaw(doc);
+      const result = schema.safeParse(raw);
+      if (result.success) {
+        validated.push(result.data);
+      } else {
+        console.error("Invalid Firestore document:", doc.id, result.error);
+      }
+    } catch (err) {
+      console.error("Unexpected error while validating doc:", doc.id, err);
     }
-  });
+  }
 
   return validated;
 }
 
-// validate a single document
+// Synchronous helper validator for use inside onSnapshot callbacks.
+// Accepts a QuerySnapshot<DocumentData> or snapshot-like object ({ docs: any[] }).
+
+export function getValidatedDocsFromSnapshot<T>(
+  snapshot: QuerySnapshot<DocumentData> | { docs: any[] },
+  schema: z.ZodSchema<T>
+): T[] {
+  const validated: T[] = [];
+
+  for (const doc of (snapshot as any).docs) {
+    try {
+      const raw = normalizeDocRaw(doc);
+      const result = schema.safeParse(raw);
+      if (result.success) validated.push(result.data);
+      else
+        console.error(
+          "Invalid Firestore document (snapshot):",
+          doc.id,
+          result.error
+        );
+    } catch (err) {
+      console.error(
+        "Unexpected error while validating snapshot doc:",
+        doc.id,
+        err
+      );
+    }
+  }
+
+  return validated;
+}
+
+// Validate a single document reference (getDoc)
 export async function getValidatedDoc<T>(
   docRef: DocumentReference,
   schema: z.ZodSchema<T>
@@ -42,7 +107,8 @@ export async function getValidatedDoc<T>(
   const docSnap = await getDoc(docRef);
   if (!docSnap.exists()) return null;
 
-  const result = schema.safeParse({ id: docSnap.id, ...docSnap.data() });
+  const raw = normalizeDocRaw(docSnap);
+  const result = schema.safeParse(raw);
   if (!result.success) {
     console.error("Invalid Firestore document:", docSnap.id, result.error);
     return null;

--- a/validation/vacationSchemas.ts
+++ b/validation/vacationSchemas.ts
@@ -62,5 +62,6 @@ export const FirestoreVacationSchema = z.object({
     .regex(/^\d{4}-\d{2}-\d{2}$/, "startDate must be YYYY-MM-DD"),
   markedDates: MarkedDatesSchema,
   createdAt: timestampToDateOptional,
+  reminderDuration: z.number().optional(),
 });
 export type FirestoreVacation = z.infer<typeof FirestoreVacationSchema>;


### PR DESCRIPTION
## Titel  
Validate VacationList ( Firestore reads ) — snapshot-safe wrapper + tests

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [x] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
- Add snapshot-safe validation wrapper (`validation/getDocsWrapper.ts`)  
  - `normalizeDocRaw`, `getValidatedDocs` accepts collection *or* snapshot-like object, `getValidatedDocsFromSnapshot` for `onSnapshot`.
- Use wrapper in `components/VacationList.tsx` (validate snapshot → map `markedDates` → sort → set state).
- Extend `validation/vacationSchemas.ts` with optional `reminderDuration`.
- Add test `__tests__/getDocsWrapper.vacation.test.ts` (mocks snapshot, asserts invalid doc is logged).

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed (high level)
- `validation/getDocsWrapper.ts` (updated)
- `validation/vacationSchemas.ts` (updated)
- `components/VacationList.tsx` (updated)
- `__tests__/getDocsWrapper.vacation.test.ts` (added)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Notes
- Wrapper centralizes Zod validation for both `getDocs` and `onSnapshot`.
