### PR TITLE
Security/validate details screen

### DIFF
--- a/__tests__/schemas.test.ts
+++ b/__tests__/schemas.test.ts
@@ -49,6 +49,7 @@ describe("Firestore Schemas", () => {
       totpEnabled: true,
       totpSecret: "SECRET123",
       hasSeenHomeTour: false,
+      hasSeenDetailsTour: true,
     };
     expect(FirestoreUserSchema.safeParse(data).success).toBe(true);
   });
@@ -62,10 +63,25 @@ describe("Firestore Schemas", () => {
       expect(result.data.firstLogin).toBe(false);
       expect(result.data.totpEnabled).toBe(false);
       expect(result.data.hasSeenHomeTour).toBe(false);
+      expect(result.data.hasSeenDetailsTour).toBe(false);
     }
   });
 
-  //WorkHoursScreen Tour
+  // DetailsScreen Tour
+  it("applies defaults for details tour flag", () => {
+    const data = { email: "user@example.com" };
+    const result = FirestoreUserSchema.safeParse(data);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.hasSeenDetailsTour).toBe(false);
+  });
+
+  it("respects hasSeenDetailsTour when present", () => {
+    const r = FirestoreUserSchema.safeParse({ hasSeenDetailsTour: true });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.hasSeenDetailsTour).toBe(true);
+  });
+
+  // WorkHoursScreen Tour
   it("applies defaults for workhours tour flag", () => {
     const data = { email: "user@example.com" };
     const result = FirestoreUserSchema.safeParse(data);

--- a/validation/firestoreSchemas.ts
+++ b/validation/firestoreSchemas.ts
@@ -50,6 +50,7 @@ export const FirestoreUserSchema = z.object({
   hasSeenHomeTour: z.boolean().optional().default(false),
   hasSeenVacationTour: z.boolean().optional().default(false),
   hasSeenWorkHoursTour: z.boolean().optional().default(false),
+  hasSeenDetailsTour: z.boolean().optional().default(false),
   createdAt: timestampToDateOptional, // optional, converted to Date when present
 });
 export type FirestoreUser = z.infer<typeof FirestoreUserSchema>;


### PR DESCRIPTION
# Validate DetailsScreen Tour Status — Firestore Zod validation

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [X] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
- Implement Zod validation for Firestore user data in DetailsScreen component
- Extend FirestoreUserSchema with `hasSeenDetailsTour` field
- Add comprehensive test coverage for tour status validation
- Implement fail-secure defaults for invalid Firestore data

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed
- `components/DetailsScreen.tsx` - Added Firestore data validation
- `validation/firestoreSchemas.ts` - Extended schema
- `__tests__/schemas.test.ts` - Added validation tests

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Notes
- Ensures type safety for Firestore user data reads
- Fail-secure approach: defaults to no tour on validation errors
- Consistent with existing tour flag patterns
- Zod handles automatic type checking