### PR TITLE
Security/validate login auth in app file

### DIFF
--- a/__tests__/authHelper.test.ts
+++ b/__tests__/authHelper.test.ts
@@ -1,0 +1,108 @@
+/////////////////////////////authHelper.test.ts////////////////////////////////
+
+// Tests AppSec-relevante Logik von handleAuthStateChange
+
+///////////////////////////////////////////////////////////////////////////////
+
+import { getDoc } from "firebase/firestore";
+
+import { FirestoreUserSchema } from "../validation/firestoreSchemas";
+import { handleAuthStateChange } from "../validation/authHelper";
+
+///////////////////////////////////////////////////////////////////////////////
+
+// Firebase & Schema Mocks
+jest.mock("firebase/firestore", () => ({
+  getDoc: jest.fn(),
+  doc: jest.fn(),
+}));
+
+jest.mock("../firebaseConfig", () => ({
+  FIREBASE_FIRESTORE: {},
+}));
+
+jest.mock("../validation/firestoreSchemas", () => ({
+  FirestoreUserSchema: {
+    safeParse: jest.fn(),
+  },
+}));
+
+// Tests
+describe("handleAuthStateChange (AppSec validation)", () => {
+  const mockSetUser = jest.fn();
+  const mockUser = { uid: "123", email: "test@example.com" } as any;
+
+  // clear mocks before each test
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should logout if no user is passed", async () => {
+    await handleAuthStateChange(null, mockSetUser);
+    expect(mockSetUser).toHaveBeenCalledWith(null);
+  });
+
+  it("should set user if Firestore doc does not exist", async () => {
+    (getDoc as jest.Mock).mockResolvedValueOnce({ exists: () => false });
+
+    await handleAuthStateChange(mockUser, mockSetUser);
+
+    expect(getDoc).toHaveBeenCalled();
+    expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+  });
+
+  it("should block login if Firestore data is invalid (schema fail)", async () => {
+    (getDoc as jest.Mock).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ email: "invalid@example" }),
+    });
+    (FirestoreUserSchema.safeParse as jest.Mock).mockReturnValueOnce({
+      success: false,
+      error: new Error("invalid schema"),
+    });
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    await handleAuthStateChange(mockUser, mockSetUser);
+    warnSpy.mockRestore();
+
+    expect(mockSetUser).toHaveBeenCalledWith(null);
+  });
+
+  it("should block login if totpEnabled is true", async () => {
+    (getDoc as jest.Mock).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ email: "t@example.com", totpEnabled: true }),
+    });
+    (FirestoreUserSchema.safeParse as jest.Mock).mockReturnValueOnce({
+      success: true,
+      data: { totpEnabled: true },
+    });
+
+    await handleAuthStateChange(mockUser, mockSetUser);
+    expect(mockSetUser).not.toHaveBeenCalled();
+  });
+
+  it("should set user if totpEnabled is false", async () => {
+    (getDoc as jest.Mock).mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ email: "t@example.com", totpEnabled: false }),
+    });
+    (FirestoreUserSchema.safeParse as jest.Mock).mockReturnValueOnce({
+      success: true,
+      data: { totpEnabled: false },
+    });
+
+    await handleAuthStateChange(mockUser, mockSetUser);
+    expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+  });
+
+  it("should log and set user if an exception occurs", async () => {
+    (getDoc as jest.Mock).mockRejectedValueOnce(new Error("Firestore down"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await handleAuthStateChange(mockUser, mockSetUser);
+
+    errSpy.mockRestore();
+    expect(mockSetUser).toHaveBeenCalledWith(mockUser);
+  });
+});

--- a/validation/authHelper.ts
+++ b/validation/authHelper.ts
@@ -1,0 +1,64 @@
+//////////////////////////////////authHelper.ts////////////////////////////////////
+
+/**
+ * - Validates the user's Firestore doc before deciding to call setUser(u)
+ * - If Firestore doc is invalid -> avoid auto-login (setUser(null))
+ * - If totpEnabled === true -> DO NOT setUser (login flow must handle TOTP)
+ * - On Firestore errors: logs and falls back to setUser(u) to avoid locking the user out.
+ */
+
+///////////////////////////////////////////////////////////////////////////////////
+
+import { doc, getDoc } from "firebase/firestore";
+import { User } from "firebase/auth";
+
+import { FIREBASE_FIRESTORE } from "../firebaseConfig";
+import { FirestoreUserSchema } from "./firestoreSchemas";
+
+///////////////////////////////////////////////////////////////////////////////////
+
+export const handleAuthStateChange = async (
+  u: User | null,
+  setUser: (u: User | null) => void
+) => {
+  // No user -> explicit logout
+  if (!u) {
+    setUser(null);
+    return;
+  }
+
+  try {
+    // get user doc from firestore to check if TOTP is enabled
+    const uref = doc(FIREBASE_FIRESTORE, "Users", u.uid);
+    const snap = await getDoc(uref);
+
+    if (!snap.exists()) {
+      // No user doc: OK to set auth user (no TOTP info)
+      setUser(u);
+      return;
+    }
+
+    const raw = snap.data() as unknown;
+    const parsed = FirestoreUserSchema.safeParse(raw);
+
+    if (!parsed.success) {
+      // AppSec: don't trust invalid firestore data — block auto-login
+      console.warn("[Auth] invalid user doc:", parsed.error);
+      setUser(null);
+      return;
+    }
+
+    // If TOTP is enabled block auto-login: don't set the user (Login screen handles TOTP flow)
+    if (parsed.data.totpEnabled) {
+      // NOT seUser(u);
+      return;
+    }
+
+    // set the Firebase auth user into app state
+    setUser(u);
+  } catch (err) {
+    // log and fallback to set user (avoid leaving app in limbo)
+    console.error("[Auth] handleAuthStateChange error:", err);
+    setUser(u);
+  }
+};


### PR DESCRIPTION
## Title
AppSec Validation for Auth Flow – handleAuthStateChange in App.tsx

## Type of Changes
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Rendering/style changes  
- [x] 🧪 test: Tests added/changed  
- [x] 🔧 chore: Maintenance work  
- [ ] 🎭 ui: UI changes  

---

## Description
This PR introduces AppSec-relevant validation for the authentication flow in `App.tsx` using the `handleAuthStateChange` helper.  

Key points:

- Delegates the Firebase `onAuthStateChanged` logic to `handleAuthStateChange` for centralized validation.
- Validates Firestore user documents using Zod (`FirestoreUserSchema`) before setting app state.
- Prevents auto-login if Firestore data is invalid (`setUser(null)`).
- Ensures users with `totpEnabled` are handled by the login flow and are not auto-logged-in.
- Handles Firestore errors safely and falls back to `setUser(u)` to avoid locking users out.
- Refactors `App.tsx` hook logic into the helper to maintain AppSec consistency.

## Changes
- Updated `App.tsx`:
  - Hook for `onAuthStateChanged` now delegates to `handleAuthStateChange`.
  - Extracted logic to validate user Firestore doc using Zod.
- Added `handleAuthStateChange` helper in `validation/authHelper.ts`.
- Added Jest tests in `__tests__/authHelper.test.ts` covering:
  - No user
  - Firestore doc missing
  - Invalid Firestore doc
  - TOTP enabled
  - Firestore read errors

## Files Changed
- `App.tsx` (hook refactored to delegate to `handleAuthStateChange`)  
- `validation/authHelper.ts` (added)  
- `__tests__/authHelper.test.ts` (added)

## Notes
This PR ensures AppSec validation is applied at the authentication initialization layer.  
All critical branches are tested to prevent invalid or insecure auto-login scenarios.  