### PR TITLE
Fix/rules emulator tracker UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -45,7 +45,10 @@ import { useAlertStore } from "./components/services/customAlert/alertStore";
 import { NotificationManager } from "./components/services/PushNotifications";
 import { useAccessibilityStore } from "./components/services/accessibility/accessibilityStore";
 import { AuthProvider } from "./components/contexts/AuthContext";
-import { ServiceProvider } from "./components/contexts/ServiceContext";
+import {
+  ServiceProvider,
+  useService,
+} from "./components/contexts/ServiceContext";
 import { navigationRef } from "./navigation/NavigationRef";
 import { AuthContext } from "./components/contexts/AuthContext";
 import { AuthStateListener } from "./onAuthStageChanges";
@@ -187,6 +190,7 @@ SplashScreen.preventAutoHideAsync();
 // AppNavigator - reads Context for Routing
 const AppNavigator = () => {
   const { stage, isTwoFAEnabled } = useContext(AuthContext);
+  const { serviceId } = useService();
 
   useEffect(() => {
     if (!navigationRef.isReady()) return;
@@ -260,19 +264,31 @@ const AppNavigator = () => {
           headerLeft: () => (
             <TouchableOpacity
               onPress={async () => {
-                const projectId = useStore.getState().getProjectId();
-                const isTracking = await useStore
-                  .getState()
-                  .getProjectTrackingState(projectId);
+                try {
+                  const projectId = useStore.getState().getProjectId();
 
-                if (isTracking) {
-                  useAlertStore
+                  if (!projectId || !serviceId) {
+                    console.warn("[BACK] no projectId");
+                    navigation.goBack();
+                    return;
+                  }
+
+                  const isTracking = await useStore
                     .getState()
-                    .showAlert(
-                      "Project is still running.",
-                      " You can't leave the app. Please stop the project first.",
-                    );
-                } else {
+                    .getProjectTrackingState(projectId, serviceId);
+
+                  if (isTracking) {
+                    useAlertStore
+                      .getState()
+                      .showAlert(
+                        "Project is still running.",
+                        "You can't leave the app. Please stop the project first.",
+                      );
+                  } else {
+                    navigation.goBack();
+                  }
+                } catch (err) {
+                  console.error("[BACK ERROR]", err);
                   navigation.goBack();
                 }
               }}

--- a/Screens/DetailsScreen.tsx
+++ b/Screens/DetailsScreen.tsx
@@ -47,14 +47,25 @@ const DetailsScreen: React.FC = () => {
   // declare the route params
   const route = useRoute<DetailsScreenRouteProp>();
 
+  // use routing to get serviceId
+  const { serviceId } = useStore();
+  // use routing to get projectId
+  const { projectId } = route.params || {};
+
+  useEffect(() => {
+    if (projectId) setProjectId(projectId);
+    return () => {
+      console.log("[DetailsScreen] UNMOUNT");
+    };
+  }, [projectId]);
+
   // declare the copilot offset
   const offset = useCopilotOffset();
 
   // declare Firebase Auth
   const auth: Auth = getAuth(FIREBASE_APP);
 
-  // use routing to get projectId
-  const { projectId } = route.params || {};
+  if (!projectId) return null;
 
   // get the current project id from the store
   const { setProjectId, isTracking } = useStore();
@@ -121,7 +132,7 @@ const DetailsScreen: React.FC = () => {
         }
       };
       fetchTourStatus();
-    }, [auth.currentUser?.uid])
+    }, [auth.currentUser?.uid]),
   );
 
   // hook to control the copilot tour card + animation timing to get visibility
@@ -232,7 +243,7 @@ const DetailsScreen: React.FC = () => {
                 {/* Progress Card */}
                 <ProgressCard
                   projectId={projectId}
-                  serviceId="AczkjyWoOxdPAIRVxjy3"
+                  serviceId={serviceId}
                   maxHoursFromDB={maxHoursFromDB}
                 />
               </ErrorBoundary>

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -37,6 +37,7 @@ import {
   deleteDoc,
   addDoc,
   getDoc,
+  serverTimestamp,
 } from "firebase/firestore";
 import { getAuth, Auth } from "firebase/auth";
 import { LinearGradient } from "expo-linear-gradient";
@@ -68,6 +69,7 @@ import { useAlertStore } from "../components/services/customAlert/alertStore";
 import { useDotAnimation } from "../components/DotAnimation";
 import { sanitizeTitle } from "../components/InputSanitizers";
 import SortModal from "../components/SortModal";
+import { normalizeCreatedAt } from "../components/helper/normalizeCreatedAt.helper";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -81,7 +83,7 @@ type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList>;
 interface Project {
   id: string;
   name: string;
-  createdAt: Date;
+  createdAt: Date | null;
   [key: string]: any;
 }
 
@@ -107,7 +109,7 @@ const HomeScreen: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
 
   // state to handle if the user can read the projects
-  const [canReadProjects, setCanReadProjects] = useState(false);
+  const [canReadProjects, setCanReadProjects] = useState<boolean | null>(null);
 
   // states to control the loading screen
   const [minTimePassed, setMinTimePassed] = useState(false);
@@ -123,7 +125,7 @@ const HomeScreen: React.FC = () => {
   const auth: Auth = getAuth(FIREBASE_APP);
 
   // declare the service id
-  const { serviceId } = useService();
+  const { serviceId, loading: serviceLoading } = useService();
 
   // initialize the project id globally to reset all components in the details screen
   const { setProjectId } = useStore();
@@ -151,11 +153,17 @@ const HomeScreen: React.FC = () => {
   // function to sort the projects
   const sortedProjects = React.useMemo(() => {
     return [...projects].sort((a, b) => {
+      const aDate = normalizeCreatedAt(a.createdAt);
+      const bDate = normalizeCreatedAt(b.createdAt);
+
+      const aTime = aDate ? aDate.getTime() : 0;
+      const bTime = bDate ? bDate.getTime() : 0;
+
       switch (sortOrder) {
         case "DATE_DESC":
-          return b.createdAt.getTime() - a.createdAt.getTime();
+          return bTime - aTime;
         case "DATE_ASC":
-          return a.createdAt.getTime() - b.createdAt.getTime();
+          return aTime - bTime;
         case "NAME_ASC":
           return a.name.localeCompare(b.name);
         case "NAME_DESC":
@@ -199,120 +207,173 @@ const HomeScreen: React.FC = () => {
 
   // Gatecheck to check if the user can read the projects
   useEffect(() => {
-    if (!serviceId) return;
-    const checkCanReadProjects = async () => {
+    if (serviceLoading) return;
+    if (!serviceId) {
+      setCanReadProjects(false);
+      return;
+    }
+
+    let active = true;
+
+    const check = async () => {
       const user = FIREBASE_AUTH.currentUser;
+
       if (!user) {
-        setCanReadProjects(false);
-        setIsLoading(false);
+        if (active) setCanReadProjects(false);
         return;
       }
+
+      if (active) setCanReadProjects(null);
+
       try {
         const serviceRef = doc(
           FIREBASE_FIRESTORE,
           "Users",
           user.uid,
           "Services",
-          serviceId
+          serviceId,
         );
 
-        const serviceSnap = await getDoc(serviceRef);
-        if (!serviceSnap.exists()) {
-          setCanReadProjects(true);
-        } else {
-          setCanReadProjects(true);
-        }
-      } catch {
-        // expected on first entry
-        setCanReadProjects(false);
-      } finally {
-        setIsLoading(false);
+        const snap = await getDoc(serviceRef);
+
+        if (!active) return;
+
+        setCanReadProjects(snap.exists());
+      } catch (err) {
+        if (active) setCanReadProjects(false);
       }
     };
 
-    checkCanReadProjects();
-  }, [serviceId]);
+    check();
+
+    return () => {
+      active = false;
+    };
+  }, [serviceId, serviceLoading]);
 
   // function to load data from firestore
   useEffect(() => {
-    let cancelled = false;
-    setIsLoading(true);
+    if (serviceLoading) return;
+    if (canReadProjects === null) return;
+
+    let active = true;
 
     const fetchProjects = async () => {
-      if (!canReadProjects || !serviceId) {
-        setIsLoading(false);
-        return;
-      }
       const user = FIREBASE_AUTH.currentUser;
-      if (!user) {
-        setIsLoading(false);
+
+      if (!serviceId || !user) {
+        if (active) setIsLoading(false);
         return;
       }
 
-      const projectsCollection = collection(
-        FIREBASE_FIRESTORE,
-        "Users",
-        user.uid,
-        "Services",
-        serviceId,
-        "Projects"
-      );
+      if (canReadProjects === false) {
+        if (active) setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
 
       try {
+        const projectsCollection = collection(
+          FIREBASE_FIRESTORE,
+          "Users",
+          user.uid,
+          "Services",
+          serviceId,
+          "Projects",
+        );
+
         const snapshot = await getDocs(projectsCollection);
 
-        // mapping projectsData
-        const projectsData = snapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...doc.data(),
-          createdAt: doc.data().createdAt ?? new Date(),
-        }));
+        if (!active) return;
 
-        setProjects(projectsData as any);
+        setProjects(
+          snapshot.docs.map((doc) => {
+            const data = doc.data();
+            return {
+              id: doc.id,
+              ...data,
+              name: data.name ?? "",
+              createdAt: normalizeCreatedAt(data.createdAt),
+            };
+          }),
+        );
       } catch (err) {
         console.error("Error fetching projects", err);
       } finally {
-        setIsLoading(false);
+        if (active) setIsLoading(false);
       }
     };
 
     fetchProjects();
+
     return () => {
-      cancelled = true;
+      active = false;
     };
-  }, [canReadProjects, refresh, serviceId]);
+  }, [serviceId, serviceLoading, canReadProjects, refresh]);
 
   // function to add projects
   const handleAddProject = async () => {
-    if (!serviceId) return;
-    if (!newProjectName.trim()) {
+    const user = FIREBASE_AUTH.currentUser;
+    if (!user?.uid) return;
+
+    if (!user) {
+      useAlertStore.getState().showAlert("Error", "User not authenticated.");
+      return;
+    }
+
+    if (!serviceId) {
+      useAlertStore
+        .getState()
+        .showAlert(
+          "Error",
+          "serviceId is missing. ServiceContext is not ready.",
+        );
+      return;
+    }
+
+    const trimmedName = newProjectName.trim();
+    if (!trimmedName.trim()) {
       useAlertStore
         .getState()
         .showAlert("Sorry", "Add a project title first to continue.");
       return;
     }
 
-    if (newProjectName.length > 100) {
+    if (trimmedName.length > 100) {
       useAlertStore.getState().showAlert("Error", "Project name too long");
       return;
     }
 
     try {
-      const user = FIREBASE_AUTH.currentUser;
-      if (!user) return;
-
-      const db = FIREBASE_FIRESTORE;
       const projectsCollection = collection(
-        db,
+        FIREBASE_FIRESTORE,
         "Users",
         user.uid,
         "Services",
         serviceId,
-        "Projects"
+        "Projects",
       );
 
       const projectToAdd = {
-        uid: user.uid,
+        userId: user.uid,
+        name: trimmedName,
+        createdAt: serverTimestamp(),
+        timer: 0,
+        elapsedTime: 0,
+        hourlyRate: 0,
+        totalEarnings: 0,
+        isTracking: false,
+        startTime: null,
+        endTime: null,
+        lastStartTime: null,
+        originalStartTime: null,
+      };
+
+      const newProjectRef = await addDoc(projectsCollection, projectToAdd);
+
+      const projectForState = {
+        userId: user.uid,
         name: newProjectName,
         createdAt: new Date(),
         timer: 0,
@@ -321,23 +382,19 @@ const HomeScreen: React.FC = () => {
         totalEarnings: 0,
         isTracking: false,
         startTime: null,
-        pauseTime: null,
         endTime: null,
         lastStartTime: null,
         originalStartTime: null,
+        id: newProjectRef.id,
       };
-
-      const newProjectRef = await addDoc(projectsCollection, projectToAdd);
-
-      setProjects((prev) => [
-        ...prev,
-        { id: newProjectRef.id, ...projectToAdd },
-      ]);
+      setProjects((prev) => [...prev, projectForState]);
       setNewProjectName("");
       setRefresh((r) => !r);
       Keyboard.dismiss();
+      console.log("serviceId:", serviceId);
     } catch (error) {
       console.error("Error adding project", error);
+      useAlertStore.getState().showAlert("Error", "Could not add project.");
     }
   };
 
@@ -375,24 +432,27 @@ const HomeScreen: React.FC = () => {
                     .showAlert("Error", "User not authenticated.");
                   return;
                 }
-
+                if (!serviceId) {
+                  console.error("Missing serviceId");
+                  return;
+                }
                 const db = FIREBASE_FIRESTORE;
                 const noteCollection = collection(
                   db,
                   "Users",
                   user.uid,
                   "Services",
-                  "AczkjyWoOxdPAIRVxjy3",
+                  serviceId,
                   "Projects",
                   projectId,
-                  "Notes"
+                  "Notes",
                 );
                 // snapshot to delete notes
                 const notesSnapshot = await getDocs(noteCollection);
 
                 // wait for all note deletions to finish before deleting the project
                 await Promise.all(
-                  notesSnapshot.docs.map((doc) => deleteDoc(doc.ref))
+                  notesSnapshot.docs.map((doc) => deleteDoc(doc.ref)),
                 );
                 // now delete the project
                 const projectDocRef = doc(
@@ -400,9 +460,9 @@ const HomeScreen: React.FC = () => {
                   "Users",
                   user.uid,
                   "Services",
-                  "AczkjyWoOxdPAIRVxjy3",
+                  serviceId,
                   "Projects",
-                  projectId
+                  projectId,
                 );
                 await deleteDoc(projectDocRef);
 
@@ -415,7 +475,7 @@ const HomeScreen: React.FC = () => {
               }
             },
           },
-        ]
+        ],
       );
   };
 
@@ -650,7 +710,7 @@ const HomeScreen: React.FC = () => {
   useFocusEffect(
     useCallback(() => {
       fetchTourStatus();
-    }, [])
+    }, []),
   );
 
   // delay the setting of showTourCard
@@ -670,7 +730,7 @@ const HomeScreen: React.FC = () => {
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
   // console.log("accessMode in LoginScreen:", accessMode);
 
@@ -852,7 +912,7 @@ const HomeScreen: React.FC = () => {
                     keyExtractor={(item) => item.id}
                     onScroll={Animated.event(
                       [{ nativeEvent: { contentOffset: { y: scrollY } } }],
-                      { useNativeDriver: true }
+                      { useNativeDriver: true },
                     )}
                     scrollEventThrottle={16}
                     renderItem={renderItem}

--- a/Screens/LoginScreen.tsx
+++ b/Screens/LoginScreen.tsx
@@ -156,7 +156,6 @@ const LoginScreen: React.FC = () => {
         await NotificationManager.savePushTokenToDatabase(uid, token);
         await NotificationManager.sendWelcomeNotification(token);
       }
-
       // Navigation
       setUser(response.user);
       setStage("authenticated");

--- a/Screens/WorkHoursScreen.tsx
+++ b/Screens/WorkHoursScreen.tsx
@@ -13,7 +13,6 @@ import { CopilotProvider } from "react-native-copilot";
 import { getDoc } from "firebase/firestore";
 
 import { FIREBASE_APP, FIREBASE_FIRESTORE } from "../firebaseConfig";
-import WorkHoursState from "../components/WorkHoursState";
 import WorkHoursInput from "../components/WorkHoursInput";
 import WorkTimeTracker from "../components/WorkTimeTracker";
 import WorkHoursChart from "../components/WorkHoursChart";
@@ -37,9 +36,6 @@ type WorkHoursScreenRouteProps = {
 const WorkHoursScreen: React.FC<WorkHoursScreenRouteProps> = () => {
   // initialize the copilot offset
   const offset = useCopilotOffset();
-
-  // initialize WorkHoursState
-  const {} = WorkHoursState();
 
   // initialize Firebase Auth
   const auth: Auth = getAuth(FIREBASE_APP);
@@ -81,7 +77,7 @@ const WorkHoursScreen: React.FC<WorkHoursScreenRouteProps> = () => {
       };
 
       fetchTourStatus();
-    }, [])
+    }, []),
   );
 
   // delay the setting of showTourCard

--- a/__tests__/asyncStorageSchemas.client.test.ts
+++ b/__tests__/asyncStorageSchemas.client.test.ts
@@ -55,13 +55,13 @@ describe("AsyncStorageWorkTrackerSchema (client)", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects non-integer elapsedTime", () => {
+  it("accepts non-integer elapsedTime (float allowed)", () => {
     const result = AsyncStorageWorkTrackerSchema.safeParse({
       ...validBase,
       elapsedTime: 12.5,
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("rejects accumulatedDuration above max (10 years)", () => {

--- a/__tests__/useValidatedStore.client.test.ts
+++ b/__tests__/useValidatedStore.client.test.ts
@@ -55,34 +55,50 @@ describe("useValidatedStore", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it("calls store.setProjectData on valid input", () => {
     jest
       .spyOn(schemas, "validateSetProjectData")
       .mockImplementation((data) => data as any);
+
     storeWrapper.setProjectData("validProject", { id: "validProject" });
-    expect(mockStore.setProjectData).toHaveBeenCalledWith("validProject", {
-      id: "validProject",
-    });
+
+    expect(mockStore.setProjectData).toHaveBeenCalledTimes(1);
+    const [projectId, projectData] = mockStore.setProjectData.mock.calls[0];
+    expect(projectId).toBe("validProject");
+    expect(projectData).toEqual({ id: "validProject" });
   });
 
   it("calls store.setTimerAndEarnings with validated data", () => {
     jest
       .spyOn(schemas, "validateTimerAndEarnings")
       .mockImplementation((data) => data as any);
+
     storeWrapper.setTimerAndEarnings("validProject", 100, 200);
-    expect(mockStore.setTimerAndEarnings).toHaveBeenCalledWith(
-      "validProject",
-      100,
-      200
-    );
+
+    expect(mockStore.setTimerAndEarnings).toHaveBeenCalledTimes(1);
+    const [projectId, timer, totalEarnings] =
+      mockStore.setTimerAndEarnings.mock.calls[0];
+    expect(projectId).toBe("validProject");
+    expect(timer).toBe(100);
+    expect(totalEarnings).toBe(200);
   });
 
   it("startTimer / stopTimer calls mock store", () => {
-    storeWrapper.startTimer("proj1");
-    storeWrapper.stopTimer("proj1");
-    expect(mockStore.startTimer).toHaveBeenCalledWith("proj1");
-    expect(mockStore.stopTimer).toHaveBeenCalledWith("proj1");
+    storeWrapper.startTimer("proj1", "service1");
+    storeWrapper.stopTimer("proj1", "service1");
+
+    expect(mockStore.startTimer).toHaveBeenCalledTimes(1);
+    expect(mockStore.stopTimer).toHaveBeenCalledTimes(1);
+
+    const [startProjectId, startServiceId] = mockStore.startTimer.mock.calls[0];
+    const [stopProjectId, stopServiceId] = mockStore.stopTimer.mock.calls[0];
+
+    expect(startProjectId).toBe("proj1");
+    expect(startServiceId).toBe("service1");
+    expect(stopProjectId).toBe("proj1");
+    expect(stopServiceId).toBe("service1");
   });
 });

--- a/components/EarningsCalculatorCard.tsx
+++ b/components/EarningsCalculatorCard.tsx
@@ -60,7 +60,7 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
 
   // constants for validation
@@ -70,10 +70,10 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
   // global state
   const { setHourlyRate } = useStore();
   const hourlyRate = useStore(
-    (state) => state.projects[projectId]?.hourlyRate || 0
+    (state) => state.projects[projectId]?.hourlyRate || 0,
   );
   const totalEarnings = useStore(
-    (state) => state.projects[projectId]?.totalEarnings || 0
+    (state) => state.projects[projectId]?.totalEarnings || 0,
   );
 
   // initialize local hourly rate to save the state when user navigates away from the screen
@@ -94,19 +94,13 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
         "Services",
         serviceId,
         "Projects",
-        projectId
+        projectId,
       );
 
       const docSnap = await getDoc(docRef);
       if (!docSnap.exists()) return;
 
       const data = docSnap.data();
-
-      // authorization check
-      if (data.uid !== user.uid) {
-        console.error("User not authorized to access this project");
-        return;
-      }
 
       // hourlyRate: validate client input
       let hourlyRate = 0;
@@ -181,13 +175,18 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
         .getState()
         .showAlert(
           "Invalid Rate",
-          `Hourly rate must be between ${MIN_HOURLY_RATE} and ${MAX_HOURLY_RATE}`
+          `Hourly rate must be between ${MIN_HOURLY_RATE} and ${MAX_HOURLY_RATE}`,
         );
       return;
     }
     setSaving(true);
     try {
-      await updateProjectData(projectId, { hourlyRate: rate });
+      if (!serviceId) {
+        console.error("Missing serviceId");
+        return;
+      }
+
+      await updateProjectData(projectId, serviceId, { hourlyRate: rate });
       setHourlyRate(projectId, rate);
       setRateInput("");
     } catch (error) {
@@ -209,7 +208,7 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
         <CopilotWalkthroughView
           accessible={true}
           accessibilityLabel={`Earnings calculator. Total earnings ${Number(
-            totalEarnings || 0
+            totalEarnings || 0,
           ).toFixed(2)} dollars. Your hourly rate is ${
             hourlyRate || "not set yet"
           }.`}
@@ -242,7 +241,7 @@ const EarningsCalculatorCard: React.FC<EarningsCalculatorCardProps> = ({
           <View
             accessible={true}
             accessibilityLabel={`Total earnings ${Number(
-              totalEarnings || 0
+              totalEarnings || 0,
             ).toFixed(2)} dollars`}
             style={{
               width: "80%",

--- a/components/FirestoreService.tsx
+++ b/components/FirestoreService.tsx
@@ -10,14 +10,16 @@
 import { doc, updateDoc } from "firebase/firestore";
 
 import { FIREBASE_AUTH, FIREBASE_FIRESTORE } from "../firebaseConfig";
-import { useService } from "../components/contexts/ServiceContext";
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
 // Update a project's document for the current authenticated user.
 // Returns true on success, false on failure (auth or Firestore error).
-export const updateProjectData = async (projectId: string, data: any) => {
-  const { serviceId } = useService();
+export const updateProjectData = async (
+  projectId: string,
+  serviceId: string,
+  data: any,
+) => {
   if (!serviceId) return false;
 
   const user = FIREBASE_AUTH?.currentUser;
@@ -39,7 +41,7 @@ export const updateProjectData = async (projectId: string, data: any) => {
       "Services",
       serviceId,
       "Projects",
-      projectId
+      projectId,
     );
     await updateDoc(projectDocRef, updatePayload);
     return true;

--- a/components/NoteCard.tsx
+++ b/components/NoteCard.tsx
@@ -38,7 +38,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, projectId, onDelete }) => {
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
 
   // function to handle note deletion in firestore
@@ -65,15 +65,6 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, projectId, onDelete }) => {
                 return;
               }
 
-              // minimal authorization check
-              if (note.uid !== user.uid) {
-                console.error("User not authorized to delete this note");
-                useAlertStore
-                  .getState()
-                  .showAlert("Error", "Not authorized to delete this note");
-                return;
-              }
-
               try {
                 const noteDocRef = doc(
                   FIREBASE_FIRESTORE,
@@ -84,7 +75,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, projectId, onDelete }) => {
                   "Projects",
                   projectId,
                   "Notes",
-                  note.id
+                  note.id,
                 );
                 await deleteDoc(noteDocRef);
                 onDelete(note.id);
@@ -97,7 +88,7 @@ const NoteCard: React.FC<NoteCardProps> = ({ note, projectId, onDelete }) => {
             },
             style: "destructive",
           },
-        ]
+        ],
       );
   };
 

--- a/components/NoteList.tsx
+++ b/components/NoteList.tsx
@@ -23,7 +23,7 @@ const NoteList: React.FC<{ projectId: string }> = ({ projectId }) => {
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
 
   // loaduing and error conditions

--- a/components/NoteModal.tsx
+++ b/components/NoteModal.tsx
@@ -29,6 +29,7 @@ import { useDotAnimation } from "../components/DotAnimation";
 import { sanitizeComment } from "./InputSanitizers";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
 import { NoteInputSchema } from "../validation/noteSchemas";
+import { useService } from "./contexts/ServiceContext";
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -49,7 +50,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
   // hook to announce accessibility
   useEffect(() => {
     AccessibilityInfo.announceForAccessibility(
-      "Note Modal opened. Please write your comment and press send."
+      "Note Modal opened. Please write your comment and press send.",
     );
   }, []);
 
@@ -79,12 +80,15 @@ const NoteModal: React.FC<NoteModalProps> = ({
   // function to handle comment submission
   const [saving, setSaving] = useState(false);
 
+  // get the service ID
+  const { serviceId } = useService();
+
   // function to handle comment submission
   const handleSubmitComment = async (
     projectId: string,
     comment: string,
     userId: string,
-    serviceId: string
+    serviceId: string,
   ) => {
     // Initial client-side validation
     if (!comment.trim()) {
@@ -92,7 +96,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
         .getState()
         .showAlert(
           "Sorry",
-          "Please write a comment first before pressing send."
+          "Please write a comment first before pressing send.",
         );
       return;
     }
@@ -117,16 +121,6 @@ const NoteModal: React.FC<NoteModalProps> = ({
         return;
       }
 
-      // validate the service ID
-      const VALID_SERVICE_IDS = ["AczkjyWoOxdPAIRVxjy3"];
-      if (!VALID_SERVICE_IDS.includes(serviceId)) {
-        console.error("Invalid service ID:", serviceId);
-        useAlertStore
-          .getState()
-          .showAlert("Error", "Invalid service configuration");
-        return;
-      }
-
       // authentication and authorization
       const user = FIREBASE_AUTH.currentUser;
       if (!user || user.uid !== userId) {
@@ -138,7 +132,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
       // check if project exists
       const projectRef = doc(
         FIREBASE_FIRESTORE,
-        `Users/${userId}/Services/${serviceId}/Projects/${projectId}`
+        `Users/${userId}/Services/${serviceId}/Projects/${projectId}`,
       );
 
       const projectSnapshot = await getDoc(projectRef);
@@ -151,11 +145,11 @@ const NoteModal: React.FC<NoteModalProps> = ({
       // write firestore
       const projectNotesRef = collection(
         FIREBASE_FIRESTORE,
-        `Users/${userId}/Services/${serviceId}/Projects/${projectId}/Notes`
+        `Users/${userId}/Services/${serviceId}/Projects/${projectId}/Notes`,
       );
 
       await addDoc(projectNotesRef, {
-        uid: user.uid,
+        userId: user.uid,
         comment: sanitizedComment, // use sanatized comment
         createdAt: serverTimestamp(),
       });
@@ -178,7 +172,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
 
   return (
@@ -267,14 +261,12 @@ const NoteModal: React.FC<NoteModalProps> = ({
             accessibilityLabel={saving ? "Updating profile" : "Save note"}
             accessibilityHint="Saves the note to the project"
             accessibilityState={{ busy: saving }}
-            onPress={() =>
-              handleSubmitComment(
-                projectId,
-                comment,
-                FIREBASE_AUTH.currentUser?.uid as string,
-                "AczkjyWoOxdPAIRVxjy3"
-              )
-            }
+            onPress={() => {
+              const user = FIREBASE_AUTH.currentUser;
+              if (!user || !serviceId) return;
+
+              handleSubmitComment(projectId, comment, user.uid, serviceId);
+            }}
             style={{
               width: screenWidth * 0.7, // use 70% of the screen width
               maxWidth: 400,

--- a/components/ProgressCard.tsx
+++ b/components/ProgressCard.tsx
@@ -55,7 +55,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
 
     // initialize the accessibility store
     const accessMode = useAccessibilityStore(
-      (state) => state.accessibilityEnabled
+      (state) => state.accessibilityEnabled,
     );
 
     // get the project data from the store
@@ -125,7 +125,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
             "Services",
             serviceId,
             "Projects",
-            projectId
+            projectId,
           );
 
           const projectSnap = await getDoc(projectRef);
@@ -135,7 +135,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
           }
 
           const projectData = projectSnap.data();
-          if (projectData.uid !== user.uid) {
+          if (projectData.userId !== user.uid) {
             Alert.alert("Error", "Not authorized");
             return;
           }
@@ -149,7 +149,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
           Alert.alert("Failed to save. Try again.");
         }
       }, 500),
-      [projectId, setProjectData, onSaveSuccess, serviceId]
+      [projectId, setProjectData, onSaveSuccess, serviceId],
     );
 
     // function to save the maxWorkHours
@@ -216,7 +216,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
         NotificationManager.scheduleNotification(
           "Target reached 🎯",
           "You reached your Deathline target!",
-          { seconds: 5 }
+          { seconds: 5 },
         );
       }
 
@@ -242,7 +242,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
               duration: 200,
               useNativeDriver: true,
             }),
-          ])
+          ]),
           // { iterations: 10 } // repeat the animation 10 times if it is active
         );
 
@@ -286,7 +286,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
             accessibilityLabel={
               maxWorkHours > 0 && timer > 0
                 ? `Deadline tracker. ${(displayProgress * 100).toFixed(
-                    1
+                    1,
                   )} percent of your maximum work time used. Your deadline is ${maxWorkHours} hours.`
                 : `Deadline tracker. No deadline set.`
             }
@@ -342,7 +342,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
             <TextInput
               accessible={true}
               accessibilityLabel="Enter your maximum allowed work hours"
-              placeholder="(e.g. 5)"
+              placeholder="(e.g. 5 hours)"
               placeholderTextColor={accessMode ? "white" : "grey"}
               value={inputMaxWorkHours}
               keyboardType="numeric"
@@ -488,7 +488,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
               <Text
                 accessible={true}
                 accessibilityLabel={`${(displayProgress * 100).toFixed(
-                  1
+                  1,
                 )} percent of your maximum work time used`}
                 style={{
                   color: "white",
@@ -562,7 +562,7 @@ const ProgressCard: React.FC<ProgressCardProps> = memo(
         </CopilotStep>
       </View>
     );
-  }
+  },
 );
 
 export default ProgressCard;

--- a/components/TimeTrackerCard.tsx
+++ b/components/TimeTrackerCard.tsx
@@ -24,9 +24,8 @@ import React, {
   useMemo,
 } from "react";
 import FontAwesome5 from "@expo/vector-icons/FontAwesome5";
-import FontAwesome6 from "@expo/vector-icons/FontAwesome6";
 import * as Animatable from "react-native-animatable";
-import { doc, getDoc, updateDoc, Timestamp } from "firebase/firestore";
+import { doc, getDoc } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { useRoute, RouteProp } from "@react-navigation/native";
 import { LinearGradient } from "expo-linear-gradient";
@@ -90,15 +89,25 @@ function formatTime(seconds: number, showMs = false): string {
 const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   // initialize the routing
   const route = useRoute<TimeTrackerRouteProp>();
+
+  if (!route?.params?.projectId) {
+    console.error("[TT] Missing projectId in route.params");
+    return null;
+  }
+
   const { projectId } = route.params;
   const { serviceId } = useService();
+
+  if (!serviceId) {
+    console.error(`[TT:${projectId}] Missing serviceId`);
+  }
 
   // screensize for dynamic size calculation
   const screenWidth = Dimensions.get("window").width;
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
 
   useEffect(() => {
@@ -106,11 +115,6 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
     const unsub = useStore.subscribe((state) => {
       const p = state.projects[projectId];
       if (p !== prev) {
-        // console.log(`[DBG_PROJ:${projectId}] project object changed`, {
-        //   prev,
-        //   next: p,
-        //   stack: new Error().stack?.split("\n").slice(2, 6),
-        // });
         prev = p;
       }
     });
@@ -121,7 +125,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   const lastStartTime = useStore((s) => s.projects[projectId]?.lastStartTime);
   const endTime = useStore((s) => s.projects[projectId]?.endTime);
   const originalStartTime = useStore(
-    (s) => s.projects[projectId]?.originalStartTime
+    (s) => s.projects[projectId]?.originalStartTime,
   );
 
   // project state(getProjectState is used to get the project UI state if app is started)
@@ -130,7 +134,6 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
     isTracking: false,
     lastStartTime: null,
     originalStartTime: null,
-    pauseTime: null,
     endTime: null,
     hourlyRate: 0,
     totalEarnings: 0,
@@ -141,8 +144,10 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
   const isTracking = useStore((state) => state.projects[projectId]?.isTracking);
   const appState = useStore((state) => state.appState);
   const hourlyRate = useStore(
-    (state) => state.projects[projectId]?.hourlyRate || 0
+    (state) => state.projects[projectId]?.hourlyRate || 0,
   );
+
+  const isRunning = isTracking;
 
   // validated + passthrough actions (AppSec-relevant actions via validated store)
   const {
@@ -165,7 +170,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
 
   // state only for the UI
   const [displayTime, setDisplayTime] = useState<number>(
-    projectState?.timer || 0
+    projectState?.timer || 0,
   );
 
   // formattedTime function using useMemo to get a bether performance with preventing unnecessary re-renders
@@ -180,15 +185,20 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
 
   // hook to fetch project data from firestore when navigate from home screen to details screen
   const fetchProjectData = useCallback(async () => {
-    if (!serviceId) return;
-    // console.log("Fetching project data started");
+    console.log("Fetching project data started");
     const user = getAuth().currentUser;
+
     if (!user) {
-      console.error("User is not authenticated.");
+      console.error(`[TT:${projectId}] AUTH NULL -> skip fetch`);
+      return;
+    }
+    if (!serviceId) {
+      console.error(`[TT:${projectId}] serviceId missing -> skip fetch`);
       return;
     }
 
     try {
+      console.trace(`[TT:${projectId}] fetchProjectData CALL`);
       const docRef = doc(
         FIREBASE_FIRESTORE,
         "Users",
@@ -196,32 +206,65 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
         "Services",
         serviceId,
         "Projects",
-        projectId
+        projectId,
       );
       const docSnap = await getDoc(docRef);
 
       if (docSnap.exists()) {
         const projectData = docSnap.data();
-        const formattedData = {
-          ...projectData,
-          isTracking: projectData.isTracking ?? false,
-          originalStartTime: projectData.originalStartTime
-            ? projectData.originalStartTime.toDate()
-            : null,
-          endTime: projectData.endTime ? projectData.endTime.toDate() : null,
-          lastStartTime: projectData.lastStartTime
-            ? projectData.lastStartTime.toDate()
-            : null,
+        const toDate = (v: any) => {
+          if (!v) return null;
+          if (typeof v.toDate === "function") return v.toDate();
+          return v;
         };
+
+        const formattedData = {
+          id: projectId,
+          uid: user.uid,
+
+          projectName: projectData.name ?? "",
+          name: projectData.name ?? "",
+
+          isTracking: projectData.isTracking ?? false,
+          isRestoring: false,
+
+          hourlyRate: projectData.hourlyRate ?? 0,
+          timer: projectData.timer ?? 0,
+          elapsedTime: projectData.elapsedTime ?? projectData.timer ?? 0,
+          totalEarnings: projectData.totalEarnings ?? 0,
+
+          maxWorkHours: projectData.maxWorkHours ?? 0,
+          startTimeTimestamp: projectData.startTime ?? null,
+
+          startTime: toDate(projectData.startTime),
+          endTime: toDate(projectData.endTime),
+          originalStartTime: toDate(projectData.originalStartTime),
+          lastStartTime: toDate(projectData.lastStartTime),
+        };
+        console.trace(
+          `[TT:${projectId}] setProjectData BEFORE CALL`,
+          formattedData,
+        );
+
+        console.log("ZOD INPUT DEBUG", {
+          projectId,
+          uid: formattedData.uid,
+          projectDataUid: projectData.uid,
+          storeUid: getAuth().currentUser?.uid,
+        });
+
+        console.log("VALIDATION PAYLOAD", {
+          projectId,
+          projectData: formattedData,
+          uid: formattedData.uid,
+        });
 
         try {
           // heavy validation (Zod) — Firestore → store
           setProjectData(projectId, formattedData as ProjectState);
         } catch (err) {
-          console.error(
-            `[TT:${projectId}] setProjectData validation failed on fetch:`,
-            err
-          );
+          console.error(`[TT:${projectId}] fetch crash`, err);
+          console.trace();
         }
       } else {
         console.error(`[TT:${projectId}] Project data not found in Firestore`);
@@ -229,7 +272,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
     } catch (error) {
       console.error(`[TT:${projectId}] Firestore fetch failed:`, error);
     }
-  }, [projectId, setProjectData]);
+  }, [projectId, serviceId, setProjectData]);
 
   // hook to update the hourly rate using the ref
   const hourlyRateRef = useRef(hourlyRate);
@@ -285,15 +328,28 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
 
     if (wholeSecond !== lastWholeSecondRef.current) {
       const earnings = computeEarnings(wholeSecond, hourlyRateRef.current);
+      console.trace(`[TT:${projectId}] setTimerAndEarnings BEFORE`, {
+        projectId,
+        wholeSecond,
+        earnings,
+        typeofProjectId: typeof projectId,
+        typeofWhole: typeof wholeSecond,
+        typeofEarnings: typeof earnings,
+      });
       try {
         // use the LIGHT version here (very cheap checks only)
         setTimerAndEarningsLight(projectId, wholeSecond, earnings);
       } catch (err) {
-        // hot path must not crash UI — log + continue
-        console.error(
-          `[TT:${projectId}] setTimerAndEarningsLight failed:`,
-          err
-        );
+        console.error(`[TT:${projectId}] HOT PATH CRASH`, {
+          err,
+          projectId,
+          wholeSecond,
+          earnings,
+          typeofProjectId: typeof projectId,
+          typeofWhole: typeof wholeSecond,
+          typeofEarnings: typeof earnings,
+        });
+        console.trace();
       }
       lastWholeSecondRef.current = wholeSecond;
     }
@@ -320,7 +376,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
             if (!Number.isFinite(bgEnter)) {
               console.warn(
                 `[TT:${projectId}] invalid bgTime in AsyncStorage:`,
-                storedBgTime
+                storedBgTime,
               );
               // clean up obviously bad value
               try {
@@ -331,7 +387,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
               if (!Number.isFinite(elapsedSeconds) || elapsedSeconds < 0) {
                 console.warn(
                   `[TT:${projectId}] computed invalid elapsedSeconds:`,
-                  elapsedSeconds
+                  elapsedSeconds,
                 );
                 // do not apply resume when nonsense
               } else {
@@ -343,13 +399,13 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
                 if (wholeNew < 0 || wholeNew > MAX_SECONDS) {
                   console.warn(
                     `[TT:${projectId}] implausible resumed timer:`,
-                    wholeNew
+                    wholeNew,
                   );
                   // choose to clamp or ignore — here: ignore resume and keep previous values
                 } else {
                   const earnings = computeEarnings(
                     wholeNew,
-                    hourlyRateRef.current
+                    hourlyRateRef.current,
                   );
                   try {
                     // LIGHT validation + write — cheap checks only (hot-path)
@@ -357,7 +413,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
                   } catch (err) {
                     console.error(
                       `[TT:${projectId}] bg resume setTimerAndEarningsLight failed:`,
-                      err
+                      err,
                     );
                   }
 
@@ -388,14 +444,14 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
           if (isTrackingRef.current) {
             await AsyncStorage.setItem(
               `bgTime_${projectId}`,
-              new Date().toISOString()
+              new Date().toISOString(),
             );
           }
         }
       } catch (err) {
         console.error(
           `[TimeTrackerCard:${projectId}] handleAppStateChange failed:`,
-          err
+          err,
         );
       } finally {
         setAppState(nextAppState);
@@ -404,7 +460,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
 
     const subscription: any = AppState.addEventListener(
       "change",
-      handleAppStateChange
+      handleAppStateChange,
     );
 
     return () => {
@@ -443,7 +499,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
           if (!Number.isFinite(parsedTime) || parsedTime < 0) {
             console.warn(
               `[TT:${projectId}] invalid persistedTimer value:`,
-              savedTime
+              savedTime,
             );
             // cleanup bad persisted value and fallback to 0
             try {
@@ -460,7 +516,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
             if (whole < 0 || whole > MAX_SECONDS) {
               console.warn(
                 `[TT:${projectId}] implausible persisted timer:`,
-                whole
+                whole,
               );
               try {
                 await AsyncStorage.removeItem(`persistedTimer_${projectId}`);
@@ -478,7 +534,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
               } catch (err) {
                 console.error(
                   `[TT:${projectId}] persisted timer failed heavy validation:`,
-                  err
+                  err,
                 );
                 // clear corrupted persisted value and fallback
                 try {
@@ -507,11 +563,11 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
         await Promise.all([
           AsyncStorage.setItem(
             `persistedTimer_${projectId}`,
-            accumulatedTimeRef.current.toString()
+            String(accumulatedTimeRef.current ?? 0),
           ),
           AsyncStorage.setItem(
             `isTracking_${projectId}`,
-            isTrackingRef.current.toString()
+            String(isTrackingRef.current ?? false),
           ),
         ]);
       };
@@ -525,103 +581,74 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
     };
   }, [projectId, appState]);
 
-  // hook to update the project data
-  const updateProjectData = useCallback(
-    async (data: Partial<ProjectState>) => {
-      if (!serviceId) return;
-      const user = getAuth().currentUser;
-      if (!user) {
-        console.error("User is not authenticated.");
-        return;
-      }
-
-      try {
-        const projectRef = doc(
-          FIREBASE_FIRESTORE,
-          "Users",
-          user.uid,
-          "Services",
-          serviceId,
-          "Projects",
-          projectId
-        );
-
-        // convert Date-Objects to Firestore Timestamp
-        const convertedData: Record<string, any> = {};
-        Object.entries(data).forEach(([key, value]) => {
-          if (value instanceof Date) {
-            convertedData[key] = Timestamp.fromDate(value);
-          } else {
-            convertedData[key] = value;
-          }
-        });
-
-        await updateDoc(projectRef, convertedData);
-        // console.log("Project data updated in Firestore", convertedData);
-      } catch (error) {
-        console.error("Error updating project data:", error);
-      }
-    },
-    [projectId, serviceId]
-  );
-
   // function to start the timer
   const handleStart = async () => {
+    console.trace(`[TT:${projectId}] START pressed`);
+
     const currentlyTracking =
-      useStore.getState().projects[projectId]?.isTracking;
-    // check if currently tracking
+      useStore.getState().projects?.[projectId]?.isTracking;
+
+    if (!serviceId) {
+      console.error(`[TT:${projectId}] Missing serviceId in handleStart`);
+      return;
+    }
+
     if (currentlyTracking || isTrackingRef.current) {
       console.log(`[TT:${projectId}] start skipped - already tracking`);
       return;
     }
 
-    await startTimer(projectId);
-    isTrackingRef.current = true;
-    startAnimation();
-
-    // persist the start time
     try {
-      await updateProjectData({
-        startTime: new Date(),
-        isTracking: true,
-      } as Partial<ProjectState>);
+      await startTimer(projectId, serviceId);
+
+      isTrackingRef.current = true;
+      startAnimation();
     } catch (err) {
-      console.error(
-        `[TT:${projectId}] updateProjectData failed on start:`,
-        err
-      );
-    }
-  };
-
-  // function to pause the timer
-  const handlePause = async () => {
-    if (isTrackingRef.current) {
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-        animationRef.current = null;
-      }
-
-      stopTimer(projectId);
-      isTrackingRef.current = false;
-
-      await updateProjectData({
-        isTracking: false,
-        pauseTime: new Date(),
-      } as Partial<ProjectState>);
+      console.error(`[TT:${projectId}] start crash`, err);
+      console.trace();
     }
   };
 
   // function to stop the timer
   const handleStop = async () => {
-    if (isTrackingRef.current) {
-      handlePause();
+    console.trace(`[TT:${projectId}] STOP pressed`);
+
+    if (!isTrackingRef.current) return;
+
+    if (!serviceId) {
+      console.error(`[TT:${projectId}] Missing serviceId in handleStop`);
+      return;
+    }
+
+    try {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = null;
+      }
+
+      await stopTimer(projectId, serviceId);
+      isTrackingRef.current = false;
+    } catch (err) {
+      console.error(`[TT:${projectId}] stop crash`, err);
+      console.trace();
     }
   };
 
   // function to reset the timer
   const [resetting, setResetting] = useState(false);
   const handleReset = async () => {
+    console.trace(`[TT:${projectId}] RESET pressed`);
     const project = useStore.getState().projects[projectId];
+
+    if (!serviceId) {
+      console.error(`[TT:${projectId}] Missing serviceId in handleReset`);
+      return;
+    }
+    if (!project) {
+      console.error(`[TT:${projectId}] Missing project in handleReset`);
+      return;
+    }
+
     // confirm reset
     if (project.isTracking) {
       // alert to inform the user what he has to do before pressing the reset button
@@ -630,7 +657,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
         .showAlert(
           "Attention!",
           "Please stop the project first before resetting it.",
-          [{ text: "OK", style: "default" }]
+          [{ text: "OK", style: "default" }],
         );
       return;
     }
@@ -650,15 +677,23 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
             text: "Reset",
             style: "destructive",
             onPress: async () => {
-              await resetAll(projectId);
-              accumulatedTimeRef.current = 0;
-              setDisplayTime(0);
-              await AsyncStorage.removeItem(`persistedTimer_${projectId}`);
-              await AsyncStorage.removeItem(`isTracking_${projectId}`);
-              await AsyncStorage.removeItem(`timerState_${projectId}`);
+              try {
+                setResetting(true);
+                await resetAll(projectId, serviceId);
+                accumulatedTimeRef.current = 0;
+                setDisplayTime(0);
+                await AsyncStorage.removeItem(`persistedTimer_${projectId}`);
+                await AsyncStorage.removeItem(`isTracking_${projectId}`);
+                await AsyncStorage.removeItem(`timerState_${projectId}`);
+              } catch (err) {
+                console.error(`[TT:${projectId}] reset crash`, err);
+                console.trace();
+              } finally {
+                setResetting(false);
+              }
             },
           },
-        ]
+        ],
       );
   };
 
@@ -682,7 +717,7 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
         {/* Time Tracker Card */}
         <CopilotWalkthroughView
           style={{
-            height: 600,
+            height: 650,
             marginBottom: 20,
             backgroundColor: "#191919",
             borderWidth: 1,
@@ -744,35 +779,66 @@ const TimeTrackerCard: React.FC<TimeTrackingCardsProps> = () => {
               backgroundColor: "#191919",
             }}
           >
+            {/* Start Button | Stop Button */}
             <TouchableOpacity
-              accessible={true}
-              accessibilityRole="button"
-              accessibilityLabel={"Pause the project"}
-              accessibilityHint="Press to pause the project"
-              onPress={handlePause}
+              onPress={isRunning ? handleStop : handleStart}
+              activeOpacity={0.8}
+              style={{
+                width: 140,
+                height: 140,
+                borderRadius: 70,
+                justifyContent: "center",
+                alignItems: "center",
+
+                // dynamic background
+                backgroundColor: isRunning ? "#3a0d0d" : "#003333",
+
+                // visuel feedback
+                borderWidth: 2,
+                borderColor: isRunning ? "#ff4d4d" : "aqua",
+
+                // depth
+                shadowColor: isRunning ? "#ff4d4d" : "#00ffff",
+                shadowOffset: { width: 0, height: 0 },
+                shadowOpacity: 0.6,
+                shadowRadius: 10,
+                elevation: 8,
+              }}
             >
-              <FontAwesome6 name="pause" size={65} color="lightgrey" />
-            </TouchableOpacity>
-            <TouchableOpacity
-              accessible={true}
-              accessibilityRole="button"
-              accessibilityLabel={"Start the project"}
-              accessibilityHint="Press to start the project"
-              onPress={handleStart}
-              disabled={isTracking}
-            >
-              <Animatable.View animation="pulse" iterationCount="infinite">
-                <FontAwesome5 name="play" size={85} color="lightgrey" />
-              </Animatable.View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              accessible={true}
-              accessibilityRole="button"
-              accessibilityLabel={"Stop the project"}
-              accessibilityHint="Press to stop the project"
-              onPress={handleStop}
-            >
-              <FontAwesome5 name="stop" size={52} color="lightgrey" />
+              {/* Inner Circle for depth */}
+              <View
+                style={{
+                  width: 110,
+                  height: 110,
+                  borderRadius: 55,
+                  justifyContent: "center",
+                  alignItems: "center",
+                  backgroundColor: "#111",
+                }}
+              >
+                {isRunning ? (
+                  <Animatable.View
+                    animation="pulse"
+                    iterationCount="infinite"
+                    duration={1200}
+                  >
+                    <FontAwesome5 name="stop" size={70} color="#ff4d4d" />
+                  </Animatable.View>
+                ) : (
+                  <Animatable.View
+                    animation="pulse"
+                    iterationCount="infinite"
+                    duration={1200}
+                  >
+                    <FontAwesome5
+                      name="play"
+                      size={70}
+                      color="aqua"
+                      style={{ transform: [{ translateX: +6 }] }}
+                    />
+                  </Animatable.View>
+                )}
+              </View>
             </TouchableOpacity>
           </View>
 

--- a/components/TimeTrackingState.ts
+++ b/components/TimeTrackingState.ts
@@ -14,17 +14,16 @@ import { getAuth } from "firebase/auth";
 
 import { updateProjectData } from "../components/FirestoreService";
 import { FIREBASE_FIRESTORE } from "../firebaseConfig";
-import { useService } from "../components/contexts/ServiceContext";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 export interface ProjectState {
   id: string;
+  uid: string;
   name: string;
   timer: number;
   isTracking: boolean;
   startTime: Date | null;
-  pauseTime: Date | null;
   hourlyRate: number;
   elapsedTime: number;
   totalEarnings: number;
@@ -38,6 +37,7 @@ export interface ProjectState {
 }
 
 export interface TimeTrackingState {
+  currentUser: any;
   setTimerAndEarnings: any;
   set: any;
   projects: { [key: string]: ProjectState };
@@ -46,25 +46,32 @@ export interface TimeTrackingState {
   appState: string;
   isInitialized: boolean;
   isTracking: boolean;
+  serviceId: string;
   calculateEarnings: (projectId: string | number) => void;
   setProjectId: (projectId: string) => void;
-  startTimer: (projectId: string) => void;
-  stopTimer: (projectId: string) => void;
-  pauseTimer: (projectId: string) => void;
+  startTimer(
+    projectId: string,
+    serviceId: string,
+    options?: { silent?: boolean },
+  ): Promise<void>;
+  stopTimer: (projectId: string, serviceId: string) => Promise<void>;
   updateTimer: (projectId: string, time: number) => void;
   setHourlyRate: (projectId: string, rate: number) => void;
   setTotalEarnings: (projectId: string, earnings: number) => void;
-  resetAll: (projectId: string) => void;
+  resetAll: (projectId: string, serviceId: string) => Promise<void>;
   getProjectState: (projectId: string) => ProjectState | undefined;
   setRateInput: (rate: string) => void;
   setAppState: (state: string) => void;
   setIsInitialized: (value: boolean) => void;
   setIsTracking: (value: boolean) => void;
-  getProjectTrackingState(projectId: string | null): unknown;
+  getProjectTrackingState(
+    projectId: string,
+    serviceId: string,
+  ): Promise<boolean>;
   getProjectId: () => string | null;
   setProjectData: (
     projectId: string,
-    projectData: Partial<ProjectState>
+    projectData: Partial<ProjectState>,
   ) => void;
   setProjectTime: (field: keyof ProjectState, value: any) => void;
   setLastStartTime: (projectId: string, time: Date | null) => void;
@@ -81,6 +88,8 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   lastStartTime: null,
   originalStartTime: null,
   endTime: null,
+  serviceId: "",
+  currentUser: null,
   set,
   // options to handle AppState
   rateInput: "", // globale RateInput
@@ -279,7 +288,11 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   },
 
   // function to start the timer and inform the user when a project is already being tracked
-  startTimer: async (projectId: string, { silent = false } = {}) => {
+  startTimer: async (
+    projectId: string,
+    serviceId: string,
+    { silent = false } = {},
+  ) => {
     const state = get();
     const project = state.projects[projectId];
 
@@ -311,7 +324,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
     }));
 
     try {
-      await updateProjectData(projectId, {
+      await updateProjectData(projectId, serviceId, {
         originalStartTime: updatedOriginalStartTime,
         startTime: now,
         lastStartTime: updatedLastStartTime,
@@ -324,7 +337,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   },
 
   // function to stop the timer and calculate the elapsed time
-  stopTimer: async (projectId: string) => {
+  stopTimer: async (projectId: string, serviceId: string) => {
     const state = get(); // call current state
     const project = state.projects[projectId];
 
@@ -337,7 +350,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
     // check if start time is set
     if (!project.startTime) {
       console.warn(
-        "startTime is not set. Cannot stop timer. Please start the timer first."
+        "startTime is not set. Cannot stop timer. Please start the timer first.",
       );
       return;
     }
@@ -350,13 +363,13 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
 
     // calculate elapsed time after the last startTime was set
     const elapsedTime = Math.round(
-      (new Date().getTime() - startTime.getTime()) / 1000
+      (new Date().getTime() - startTime.getTime()) / 1000,
     ); // in secunds
     // calculate final elapsed time based on project.timer if it is set
     const finalElapsedTime = Math.round(project.timer || 0);
     // calculate earnings based on finalElapsedTime and hourly rate
     const earnings = parseFloat(
-      ((finalElapsedTime / 3600) * project.hourlyRate).toFixed(2)
+      ((finalElapsedTime / 3600) * project.hourlyRate).toFixed(2),
     );
 
     // update UI
@@ -379,7 +392,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
 
     try {
       // update firestore
-      await updateProjectData(projectId, {
+      await updateProjectData(projectId, serviceId, {
         isTracking: false,
         timer: finalElapsedTime, // round the timer
         endTime: new Date(),
@@ -395,35 +408,6 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
     } catch (error) {
       console.error("Error updating Firestore in stopTimer:", error);
     }
-  },
-
-  // function to pause the timer and calculate the elapsed time
-  pauseTimer: (projectId) => {
-    set((state) => {
-      const project = state.projects[projectId];
-
-      if (!project.startTime) {
-        console.warn("startTime is not set. Cannot pause timer.");
-        return state;
-      }
-
-      // calculate elapsed time after the last startTime was set
-      const elapsedTime =
-        (new Date().getTime() - project.startTime.getTime()) / 1000;
-
-      return {
-        projects: {
-          ...state.projects,
-          [projectId]: {
-            ...project,
-            isTracking: false,
-            timer: elapsedTime,
-            endTime: new Date(),
-            startTime: null, // set startTime to null to indicate that the timer is paused
-          },
-        },
-      };
-    });
   },
 
   // statefunction to update the timer in the TimeTrackerCard
@@ -475,7 +459,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   setTimerAndEarnings: (
     projectId: string,
     timer: number,
-    totalEarnings: number
+    totalEarnings: number,
   ) =>
     set((state) => {
       // console.log(
@@ -502,17 +486,9 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
     }),
 
   // function to get the project tracking state in the TimeTrackerCard using snapshot from firebase
-  getProjectTrackingState: async (projectId: string) => {
-    const { serviceId } = useService();
-    if (!serviceId) return;
-    const user = getAuth().currentUser; // gets the current user from firebase
-    if (!user) {
-      console.error("User is not authenticated.");
-      return false;
-    }
-    if (!projectId) {
-      return false;
-    }
+  getProjectTrackingState: async (projectId: string, serviceId: string) => {
+    const user = getAuth().currentUser; // get the current user from firebase
+    if (!user || !projectId || !serviceId) return false;
 
     try {
       const docRef = doc(
@@ -522,17 +498,16 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
         "Services",
         serviceId,
         "Projects",
-        projectId
+        projectId,
       );
+
       const docSnap = await getDoc(docRef);
 
       if (docSnap.exists()) {
-        const projectData = docSnap.data();
-        return projectData.isTracking || false;
-      } else {
-        console.error("Error fetching project data:", docSnap);
-        return false;
+        return docSnap.data().isTracking || false;
       }
+
+      return false;
     } catch (error) {
       console.error("Error fetching project data:", error);
       return false;
@@ -540,7 +515,7 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
   },
 
   // statefunction to reset all properties of a project
-  resetAll: async (projectId) => {
+  resetAll: async (projectId: string, serviceId: string) => {
     set((state) => {
       const project = state.projects[projectId];
 
@@ -556,7 +531,6 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
             ...project, // hold all existing properties of the project
             isTracking: false,
             startTime: null,
-            pauseTime: null,
             endTime: null,
             hourlyRate: 0,
             elapsedTime: 0,
@@ -572,10 +546,9 @@ export const useStore = create<TimeTrackingState>((set, get) => ({
 
     // reset firestore properties
     try {
-      await updateProjectData(projectId, {
+      await updateProjectData(projectId, serviceId, {
         isTracking: false,
         startTime: null,
-        pauseTime: null,
         endTime: null,
         hourlyRate: 0,
         elapsedTime: 0,

--- a/components/VacationForm.tsx
+++ b/components/VacationForm.tsx
@@ -59,13 +59,14 @@ const VacationForm = () => {
           acc[date] = rest; // delete `customStyles` property
           return acc;
         },
-        {} as Record<string, any>
+        {} as Record<string, any>,
       );
 
       // derive startDate defensively (first sorted key)
       const startDate = Object.keys(filteredMarkedDates).sort()[0];
 
       const input = {
+        uid: user.uid,
         startDate,
         markedDates: filteredMarkedDates,
       };
@@ -74,14 +75,14 @@ const VacationForm = () => {
       if (!parsed.success) {
         console.error(
           "Vacation input validation failed:",
-          parsed.error.format()
+          parsed.error.format(),
         );
         useAlertStore
           .getState()
           .showAlert(
             "Invalid Input",
             "Vacation data is invalid. Please retry.",
-            [{ text: "OK" }]
+            [{ text: "OK" }],
           );
         return;
       }
@@ -93,7 +94,7 @@ const VacationForm = () => {
         user.uid,
         "Services",
         serviceId,
-        "Vacations"
+        "Vacations",
       );
 
       await addDoc(vacationsCollection, {

--- a/components/WorkHoursState.tsx
+++ b/components/WorkHoursState.tsx
@@ -10,7 +10,6 @@ import { getAuth } from "firebase/auth";
 import { doc, setDoc, getDoc } from "firebase/firestore";
 
 import { FIREBASE_FIRESTORE } from "../firebaseConfig";
-import { useService } from "../components/contexts/ServiceContext";
 
 ////////////////////////////////////////////////////////////////////////////
 
@@ -30,8 +29,8 @@ interface WorkHoursStateProps {
   selectedBar: any[];
   lastUpdatedDate?: string | null;
 
-  saveState: () => Promise<void>;
-  loadState: () => Promise<void>;
+  saveState: (serviceId: string) => Promise<void>;
+  loadState: (serviceId: string) => Promise<void>;
   setDocExists: (value: boolean) => void;
   setUserTimeZone: (timeZone: string) => void;
   setWorkData: (data: any[]) => void;
@@ -62,8 +61,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
   selectedBar: [],
 
   // load state from firestore
-  loadState: async () => {
-    const { serviceId } = useService();
+  loadState: async (serviceId: string) => {
     if (!serviceId) return;
     const user = getAuth().currentUser;
     if (!user) {
@@ -80,7 +78,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
         "Services",
         serviceId,
         "WorkHours",
-        today
+        today,
       );
 
       const docSnap = await getDoc(docRef);
@@ -104,8 +102,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
   },
 
   // save state to firestore
-  saveState: async () => {
-    const { serviceId } = useService();
+  saveState: async (serviceId: string) => {
     if (!serviceId) return;
     const user = getAuth().currentUser;
     if (!user) {
@@ -132,7 +129,7 @@ const WorkHoursState = create<WorkHoursStateProps>((set, get) => ({
         "Services",
         serviceId,
         "WorkHours",
-        state.currentDocId || today
+        state.currentDocId || today,
       );
 
       await setDoc(docRef, stateToSave);

--- a/components/WorkTimeTracker.tsx
+++ b/components/WorkTimeTracker.tsx
@@ -69,7 +69,7 @@ const WorkTimeTracker = () => {
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
   // console.log("accessMode in LoginScreen:", accessMode);
 
@@ -102,8 +102,9 @@ const WorkTimeTracker = () => {
 
   // hook to load state
   useEffect(() => {
-    loadState();
-  }, []);
+    if (!serviceId) return;
+    loadState(serviceId);
+  }, [serviceId]);
 
   // track currentDocId for the persistent mechanism by tracking the current day
   const currentDocIdRef = useRef(currentDocId);
@@ -127,7 +128,7 @@ const WorkTimeTracker = () => {
           "Services",
           serviceId,
           "WorkHours",
-          today
+          today,
         );
         const docSnapshot = await getDoc(docRef);
         if (docSnapshot.exists()) {
@@ -145,7 +146,7 @@ const WorkTimeTracker = () => {
           .getState()
           .showAlert(
             "Error",
-            "An error occurred while fetching the data. Please try again."
+            "An error occurred while fetching the data. Please try again.",
           );
       }
     };
@@ -235,7 +236,7 @@ const WorkTimeTracker = () => {
           const newValue = newElapsed > elapsedTime ? newElapsed : elapsedTime;
           setElapsedTime(newValue);
           setAccumulatedDuration((prev) =>
-            newElapsed > prev ? newElapsed : prev
+            newElapsed > prev ? newElapsed : prev,
           );
           // set the workflow starttime new
           setStartWorkTime(new Date());
@@ -251,7 +252,7 @@ const WorkTimeTracker = () => {
     // subscribe to app state changes
     const subscription = AppState.addEventListener(
       "change",
-      handleAppStateChange
+      handleAppStateChange,
     );
     // clear the event listener when the component unmounts
     return () => {
@@ -281,7 +282,7 @@ const WorkTimeTracker = () => {
         "Services",
         serviceId,
         "WorkHours",
-        workDay
+        workDay,
       );
 
       const docSnap = await getDoc(workRef);
@@ -349,7 +350,7 @@ const WorkTimeTracker = () => {
           "Services",
           serviceId,
           "WorkHours",
-          docIdToUse
+          docIdToUse,
         );
 
         const dataToWrite = {
@@ -358,7 +359,7 @@ const WorkTimeTracker = () => {
           elapsedTime: roundedDuration,
           overHours: Math.max(
             roundedDuration - parseFloat(expectedHours || "0"),
-            0
+            0,
           ),
           userId,
           workDay: docIdToUse,
@@ -372,7 +373,7 @@ const WorkTimeTracker = () => {
       setElapsedTime(roundedDuration);
       setStartWorkTime(null);
       setRefreshTrigger((prev) => prev + 1);
-      loadState();
+      loadState(serviceId);
     } catch (error) {
       console.error("Error in handleStopWork", error);
       useAlertStore.getState().showAlert("Error", "Failed to stop tracking");
@@ -391,8 +392,8 @@ const WorkTimeTracker = () => {
           user.uid,
           "Services",
           serviceId,
-          "WorkHours"
-        )
+          "WorkHours",
+        ),
       );
 
       return snapshot.docs.map((doc) => {
@@ -432,8 +433,8 @@ const WorkTimeTracker = () => {
             user.uid,
             "Services",
             serviceId,
-            "WorkHours"
-          )
+            "WorkHours",
+          ),
         );
 
         const formattedData = snapshot.docs
@@ -557,13 +558,13 @@ const WorkTimeTracker = () => {
             "Services",
             serviceId,
             "WorkHours",
-            docIdToCheck
+            docIdToCheck,
           );
           const docSnap = await getDoc(workRef);
           const data = docSnap.exists() ? docSnap.data() : null;
           if (!data) {
             console.warn(
-              "Saved running session exists but no firestore doc -> not auto-resuming."
+              "Saved running session exists but no firestore doc -> not auto-resuming.",
             );
             await AsyncStorage.removeItem("workTimeTrackerState");
             return;

--- a/components/contexts/ServiceContext.tsx
+++ b/components/contexts/ServiceContext.tsx
@@ -5,56 +5,80 @@
 ////////////////////////////////////////////////////////////////////////////////////
 
 import React, { createContext, useContext, useState, useEffect } from "react";
-import * as SecureStore from "expo-secure-store";
-import { nanoid } from "nanoid/non-secure";
+import { collection, getDocs, addDoc } from "firebase/firestore";
+import { onAuthStateChanged } from "firebase/auth";
+import { FIREBASE_FIRESTORE, FIREBASE_AUTH } from "../../firebaseConfig";
 
-////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////
 
 interface ServiceContextType {
   serviceId: string | null;
-  initService: () => Promise<void>;
+  loading: boolean;
 }
 
-////////////////////////////////////////////////////////////////////////////////////
+// ////////////////////////////////////////////////////////////////////////////////////
 
+// Create the context
 const ServiceContext = createContext<ServiceContextType | undefined>(undefined);
 
+// Create the provider
 export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  // declare state
   const [serviceId, setServiceId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
-  // initialize the service
-  const initService = async () => {
-    // get the serviceId from secure store
-    let storedServiceId = await SecureStore.getItemAsync("serviceId");
-    // conditionally set the serviceId
-    if (!storedServiceId) {
-      storedServiceId = nanoid();
-      await SecureStore.setItemAsync("serviceId", storedServiceId);
-    }
-    setServiceId(storedServiceId);
-  };
-
-  // hook to initialize the service
   useEffect(() => {
-    initService();
+    const unsubscribe = onAuthStateChanged(FIREBASE_AUTH, async (user) => {
+      if (!user) {
+        setServiceId(null);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        const servicesRef = collection(
+          FIREBASE_FIRESTORE,
+          "Users",
+          user.uid,
+          "Services",
+        );
+
+        const snapshot = await getDocs(servicesRef);
+
+        if (snapshot.empty) {
+          const newServiceRef = await addDoc(servicesRef, {
+            createdAt: new Date(),
+          });
+
+          setServiceId(newServiceRef.id);
+        } else {
+          setServiceId(snapshot.docs[0].id);
+        }
+      } catch (err) {
+        console.error("Service init failed", err);
+        setServiceId(null);
+      } finally {
+        setLoading(false);
+      }
+    });
+
+    return unsubscribe;
   }, []);
 
   return (
-    <ServiceContext.Provider value={{ serviceId, initService }}>
+    <ServiceContext.Provider value={{ serviceId, loading }}>
       {children}
     </ServiceContext.Provider>
   );
 };
 
-// export the useService hook
 export const useService = () => {
-  // get the context
   const context = useContext(ServiceContext);
-  // error if not in context
-  if (!context)
+  if (!context) {
     throw new Error("useService must be used within ServiceProvider");
+  }
   return context;
 };

--- a/components/helper/normalizeCreatedAt.helper.ts
+++ b/components/helper/normalizeCreatedAt.helper.ts
@@ -1,0 +1,21 @@
+//////////////////////////// normalizeCreatedAt.helper.ts ////////////////////
+
+// This file is used to normalize the created_at field in the database,
+// if a project will be rendered and sorted by created_at.
+
+///////////////////////////////////////////////////////////////////////////////
+
+export const normalizeCreatedAt = (value: unknown): Date | null => {
+  if (!value) return null;
+
+  if (value instanceof Date) return value;
+
+  if (typeof (value as any)?.toDate === "function") {
+    return (value as any).toDate();
+  }
+
+  if (typeof value === "number") return new Date(value);
+
+  const parsed = new Date(value as any);
+  return isNaN(parsed.getTime()) ? null : parsed;
+};

--- a/components/services/PushNotifications.tsx
+++ b/components/services/PushNotifications.tsx
@@ -35,7 +35,6 @@ export class NotificationManager {
         const { status: newStatus } =
           await Notifications.requestPermissionsAsync(); // request permission
         if (newStatus !== "granted") {
-          console.log("Push-Notification permission not granted.");
           return null; // if permission is not granted return null
         }
       }
@@ -64,7 +63,6 @@ export class NotificationManager {
     try {
       const userRef = doc(FIREBASE_FIRESTORE, "Users", userId); // ref for the user document
       await setDoc(userRef, { pushToken }, { merge: true }); // save the push token (merge:true prevents overwriting)
-      console.log("Push token successfully saved.");
     } catch (error) {
       console.error("Error saving push token:", error);
     }
@@ -74,7 +72,7 @@ export class NotificationManager {
   static async scheduleNotification(
     title: string,
     body: string,
-    trigger: Notifications.NotificationTriggerInput
+    trigger: Notifications.NotificationTriggerInput,
   ) {
     try {
       await Notifications.scheduleNotificationAsync({
@@ -98,7 +96,7 @@ export class NotificationManager {
     await this.scheduleNotification(
       "Welcome to ChronoCraft! ⏱️",
       "We're glad you’ve joined. Let’s track time like a pro.",
-      trigger
+      trigger,
     );
   }
 
@@ -107,7 +105,7 @@ export class NotificationManager {
     title: string,
     body: string,
     vacationDate: Date,
-    token: string
+    token: string,
   ) {
     const trigger: Notifications.NotificationTriggerInput = {
       date: vacationDate, // send notification on the vacation date (1 day, 3 days or 7 days before)

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,7 +2,6 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Check, if authenticated user is owner
     function isOwner(userId) {
       return request.auth != null && request.auth.uid == userId;
     }
@@ -11,50 +10,46 @@ service cloud.firestore {
        Users
     ======================= */
     match /Users/{userId} {
-      allow get: if isOwner(userId);
-      allow list: if false; // No User-Listing
-      allow create: if isOwner(userId);
-      allow update, delete: if false;
+
+      allow read, create, update: if isOwner(userId);
+      allow list, delete: if false;
 
       /* =======================
          Services
       ======================= */
       match /Services/{serviceId} {
-        allow get: if isOwner(userId);
-        allow list: if isOwner(userId);
-        allow create: if isOwner(userId);
+
+        allow read, create: if isOwner(userId);
         allow update, delete: if false;
 
         /* =======================
            Projects
         ======================= */
         match /Projects/{projectId} {
-          allow list: if isOwner(userId);
-          allow get, create, update, delete: if isOwner(userId);
+
+          allow read, create, update: if isOwner(userId);
+          allow delete: if isOwner(userId);
 
           /* =======================
-             Notes (Subcollection)
+             Notes
           ======================= */
           match /Notes/{noteId} {
-            allow list: if isOwner(userId);
-            allow get, create, update, delete: if isOwner(userId);
+            allow read, create, update, delete: if isOwner(userId);
           }
+        }
 
-          /* =======================
-             WorkHours (Subcollection)
-          ======================= */
-          match /WorkHours/{workHourId} {
-            allow list: if isOwner(userId);
-            allow get, create, update, delete: if isOwner(userId);
-          }
+        /* =======================
+           WorkHours (Service-level)
+        ======================= */
+        match /WorkHours/{workHourId} {
+          allow read, create, update, delete: if isOwner(userId);
+        }
 
-          /* =======================
-             Vacations (Subcollection)
-          ======================= */
-          match /Vacations/{vacationId} {
-            allow list: if isOwner(userId);
-            allow get, create, update, delete: if isOwner(userId);
-          }
+        /* =======================
+           Vacations (Service-level)
+        ======================= */
+        match /Vacations/{vacationId} {
+          allow read, create, update, delete: if isOwner(userId);
         }
       }
     }

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "types": ["node"]
   },

--- a/hooks/fetchNotesHook.ts
+++ b/hooks/fetchNotesHook.ts
@@ -10,10 +10,9 @@ import { useService } from "../components/contexts/ServiceContext";
 
 type Note = {
   id: string;
-  title?: string;
-  content?: string;
-  createdAt?: any;
-  updatedAt?: any;
+  uid: string;
+  comment: string;
+  createdAt: Date;
 };
 
 //////////////////////////////////////////////////////////////
@@ -56,16 +55,22 @@ export const useNotes = (projectId: string) => {
             serviceId,
             "Projects",
             projectId,
-            "Notes"
-          )
+            "Notes",
+          ),
         );
 
         const notesSnapshot = await getDocs(notesQuery);
 
-        const notes: Note[] = notesSnapshot.docs.map((doc) => ({
-          id: doc.id,
-          ...doc.data(),
-        }));
+        const notes: Note[] = notesSnapshot.docs.map((doc) => {
+          const data = doc.data();
+
+          return {
+            id: doc.id,
+            uid: data.uid,
+            comment: data.comment,
+            createdAt: data.createdAt?.toDate?.() ?? new Date(),
+          };
+        });
 
         setNotes(notes);
       } catch (e) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "lib",
     "strict": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "types": ["@react-native-async-storage/async-storage", "node", "jest"],
     "paths": {

--- a/validation/asyncStorageSchemas.ts
+++ b/validation/asyncStorageSchemas.ts
@@ -32,16 +32,8 @@ export const AsyncStorageWorkTrackerSchema = z
   .object({
     isWorking: z.boolean(),
     startWorkTime: isoDateStringSchema.nullable().optional(),
-    elapsedTime: z
-      .number()
-      .min(0)
-      .max(864000) // Max 1 Day in seconds
-      .refine((t) => Number.isInteger(t), "Must be whole number"),
-    accumulatedDuration: z
-      .number()
-      .min(0)
-      .max(31536000) // Max 10 Years in seconds
-      .refine((t) => Number.isInteger(t), "Must be whole number"),
+    elapsedTime: z.number().min(0).max(864000), // Max 1 Day in seconds
+    accumulatedDuration: z.number().min(0).max(31536000), // Max 10 Years in seconds
     currentDocId: z
       .string()
       .refine(isValidAsyncStorageDocId, "Invalid document ID")

--- a/validation/useValidatedStore.ts
+++ b/validation/useValidatedStore.ts
@@ -5,6 +5,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 import { UseBoundStore, StoreApi } from "zustand";
+import { getAuth } from "firebase/auth";
 
 import {
   ProjectState,
@@ -26,7 +27,7 @@ let useStore: UseBoundStore<StoreApi<TimeTrackingState>> = originalUseStore;
  * Only for Tests: Injected a Mock-Store.
  */
 export const __setUseStoreForTest = (mock: Partial<TimeTrackingState>) => {
-  // Typecast, so TS knows, that  mock is compatible
+  // Typecast, so TS knows, that mock is compatible
   useStore = (() => mock) as unknown as UseBoundStore<
     StoreApi<TimeTrackingState>
   >;
@@ -34,64 +35,118 @@ export const __setUseStoreForTest = (mock: Partial<TimeTrackingState>) => {
 
 // Hook
 export const useValidatedStore = () => {
-  const store = useStore() as any;
+  const store = useStore() as TimeTrackingState;
 
   const setProjectData = (
     projectId: string,
-    projectData: Partial<ProjectState>
+    projectData: Partial<ProjectState>,
   ) => {
-    if (!isValidProjectId(projectId))
+    if (!isValidProjectId(projectId)) {
       throw new Error(`Invalid projectId format: ${projectId}`);
-    const validatedData = validateSetProjectData({ projectId, projectData });
+    }
+    const uid = projectData.uid;
+    const validatedData = validateSetProjectData({
+      projectId,
+      projectData,
+      uid,
+    });
     store.setProjectData(validatedData.projectId, validatedData.projectData);
   };
 
   const setTimerAndEarnings = (
     projectId: string,
     timer: number,
-    totalEarnings: number
+    totalEarnings: number,
   ) => {
+    const uid = getAuth().currentUser?.uid;
+
+    console.log("SET_TIMER_AND_EARNINGS DEBUG (RAW)", {
+      projectId,
+      timer,
+      totalEarnings,
+      uid,
+      currentUser: store.currentUser,
+    });
+
+    if (!uid) {
+      console.error("CRITICAL: Missing uid in setTimerAndEarnings");
+      return;
+    }
+
     const validatedData = validateTimerAndEarnings({
       projectId,
       timer,
       totalEarnings,
+      uid,
     });
+
     store.setTimerAndEarnings(
       validatedData.projectId,
       validatedData.timer,
-      validatedData.totalEarnings
+      validatedData.totalEarnings,
     );
   };
-
   const setTimerAndEarningsLight = (
     projectId: string,
     timer: number,
-    totalEarnings: number
+    totalEarnings: number,
   ) => {
     if (!projectId || typeof projectId !== "string" || projectId.length === 0) {
       console.error(
         "setTimerAndEarningsLight ignored invalid projectId:",
-        projectId
+        projectId,
       );
       return;
     }
+
     store.setTimerAndEarnings(projectId, timer, totalEarnings);
   };
 
-  const startTimer = (projectId: string) => {
-    if (!isValidProjectId(projectId))
+  const startTimer = (
+    projectId: string,
+    serviceId: string,
+    options?: { silent?: boolean },
+  ) => {
+    if (!isValidProjectId(projectId)) {
       throw new Error(`Invalid projectId format: ${projectId}`);
-    store.startTimer(projectId);
+    }
+
+    if (!serviceId || typeof serviceId !== "string") {
+      throw new Error(`Invalid or missing serviceId: ${serviceId}`);
+    }
+
+    return store.startTimer(projectId, serviceId, options);
   };
 
-  const stopTimer = (projectId: string) => {
-    if (!isValidProjectId(projectId))
+  const stopTimer = (projectId: string, serviceId: string) => {
+    if (!isValidProjectId(projectId)) {
       throw new Error(`Invalid projectId format: ${projectId}`);
-    store.stopTimer(projectId);
+    }
+
+    if (!serviceId || typeof serviceId !== "string") {
+      throw new Error(`Invalid or missing serviceId: ${serviceId}`);
+    }
+
+    return store.stopTimer(projectId, serviceId);
+  };
+
+  const resetAll = (projectId: string, serviceId: string) => {
+    if (!isValidProjectId(projectId)) {
+      throw new Error(`Invalid projectId format: ${projectId}`);
+    }
+
+    if (!serviceId || typeof serviceId !== "string") {
+      throw new Error(`Invalid or missing serviceId: ${serviceId}`);
+    }
+
+    return store.resetAll(projectId, serviceId);
   };
 
   return {
-    // State
+    // Passthrough Actions / State
+    ...store,
+
+    // State (explicitly exposed for clarity)
     projects: store.projects,
     currentProjectId: store.currentProjectId,
     rateInput: store.rateInput,
@@ -105,8 +160,6 @@ export const useValidatedStore = () => {
     setTimerAndEarningsLight,
     startTimer,
     stopTimer,
-
-    // Passthrough Actions
-    ...store,
+    resetAll,
   };
 };

--- a/validation/vacationSchemas.ts
+++ b/validation/vacationSchemas.ts
@@ -32,7 +32,7 @@ export const MarkedDateEntrySchema = z
  */
 export const MarkedDatesSchema = z.record(
   z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  MarkedDateEntrySchema
+  MarkedDateEntrySchema,
 );
 
 /**
@@ -52,14 +52,17 @@ export type VacationInput = z.infer<typeof VacationInputSchema>;
 
 // Schema for Firestore-stored Vacation document
 const timestampToDateRequired = z.preprocess((val) => {
-  if (val == null) return undefined; // empty Value fails later
-  if ((val as any)?.toDate && typeof (val as any).toDate === "function")
+  if (val == null) return undefined;
+
+  if ((val as any)?.toDate && typeof (val as any).toDate === "function") {
     return (val as any).toDate();
+  }
+
   if (val instanceof Date) return val;
   if (typeof val === "number") return new Date(val);
   // All others: *not* set to undefined, rather return, to safeParse fails
   return val;
-}, z.date());
+}, z.date().optional());
 
 export const FirestoreVacationSchema = z.object({
   id: z.string().optional(),


### PR DESCRIPTION
## Titel  
### Align service-level Firestore flow, tracker validation, and client tests

## Type of Changes  
- [x] ✨ feat: New Feature  
- [x] 🔧 chore: Maintanance work  
- [x] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [x] 🎨 style: Change rendering  
- [x] 🧪 test: Tests added or changed  
- [x] 🎭 ui: Ui changes  

## Changes
- Reworked the app to use the **current service-level Firestore structure** consistently across screens, components, and state logic
- Removed hardcoded `serviceId` assumptions and replaced them with the active `ServiceContext`
- Updated `App.tsx`, `HomeScreen`, `DetailsScreen`, `WorkHoursScreen`, `WorkTimeTracker`, `WorkHoursState`, `ProgressCard`, `EarningsCalculatorCard`, `NoteModal`, `NoteCard`, and `NoteList` to match the new data flow
- Refactored `ServiceContext` to initialize the active service from Firestore and expose a `loading` state
- Updated `FirestoreService.updateProjectData()` to require `serviceId` explicitly
- Added `normalizeCreatedAt()` to handle `createdAt` values safely when sorting and rendering projects
- Updated project creation and note handling to use the new field names and runtime structure
- Adjusted vacation handling so `uid` is included in client validation and `createdAt` timestamp handling is tolerant of missing values
- Updated AsyncStorage validation so tracker durations allow float values instead of whole-number-only validation
- Fixed Firestore rules to match the service-level `WorkHours` and `Vacations` collections
- Removed outdated or redundant authorization checks where Firestore rules already enforce access
- Updated client tests to match the new tracker API and AsyncStorage schema behavior

## Tests  
- [x] ✅ Manual emulator testing for Firestore reads/writes and tracker flow  
- [x] ✅ Updated client tests for `useValidatedStore`  
- [x] ✅ Updated client tests for `AsyncStorage` schema validation  

## Checklist  
- [x] My changes are well-tested and commented  
- [x] I reviewed my changes  
- [x] My changes generate no new warnings  

## Dependencies  
- No new external dependencies added  
