### PR TITLE
Refactor/home screen

### DIFF
--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -206,7 +206,7 @@ const HomeScreen: React.FC = () => {
   const ITEM_HEIGHT: number = 100;
   const scrollY = useRef(new Animated.Value(0)).current;
 
-  const [averageItemHeight, setAverageItemHeight] = useState(ITEM_HEIGHT);
+  const [lastItemHeight, setLastItemHeight] = useState(ITEM_HEIGHT);
 
   // Gatecheck to check if the user can read the projects
   useEffect(() => {
@@ -253,66 +253,6 @@ const HomeScreen: React.FC = () => {
       active = false;
     };
   }, [serviceId, serviceLoading]);
-
-  //NOTE: check both hooks by testing if one of them is redundant
-  // function to load data from firestore
-  useEffect(() => {
-    if (serviceLoading) return;
-    if (canReadProjects === null) return;
-
-    let active = true;
-
-    const fetchProjects = async () => {
-      const user = FIREBASE_AUTH.currentUser;
-
-      if (!serviceId || !user) {
-        if (active) setIsLoading(false);
-        return;
-      }
-
-      if (canReadProjects === false) {
-        if (active) setIsLoading(false);
-        return;
-      }
-
-      setIsLoading(true);
-
-      try {
-        const res = await projectsAndWorkValidatorCallable({
-          action: "getProjects",
-          payload: {
-            serviceId,
-          },
-        });
-
-        const body = unwrapBody(res.data);
-
-        const projects = body?.projects ?? [];
-
-        setProjects(
-          projects.map((project: any) => ({
-            id: project.id,
-            name: project.name ?? "",
-            createdAt: normalizeCreatedAt(project.createdAt),
-            userId: project.userId,
-            status: project.status,
-            isTracking: project.isTracking,
-            hourlyRate: project.hourlyRate,
-          })),
-        );
-      } catch (err) {
-        logError("HomeScreen/fetchProjects", err);
-      } finally {
-        if (active) setIsLoading(false);
-      }
-    };
-
-    fetchProjects();
-
-    return () => {
-      active = false;
-    };
-  }, [serviceId, serviceLoading, canReadProjects, refresh]);
 
   // function to load data from firestore
   useEffect(() => {
@@ -510,8 +450,8 @@ const HomeScreen: React.FC = () => {
   const dots = useDotAnimation(loading, 700);
 
   // scroll animation with parameters to handle the scroll animation
-  const renderItem = ({ item, index }: { item: any; index: number }) => {
-    // Animation-Berechnungen
+  const renderItem = ({ item, index }: { item: Project; index: number }) => {
+    // calculate animation
     const inputRange = [
       -1,
       0,
@@ -532,26 +472,13 @@ const HomeScreen: React.FC = () => {
       extrapolate: "clamp",
     });
 
-    // converte date to enable both unix timestamps and firebase timestamps
-    let dateObj: Date | null = null;
-    if (item.createdAt) {
-      if (item.createdAt instanceof Date) {
-        dateObj = item.createdAt;
-      } else if (
-        item.createdAt.toDate &&
-        typeof item.createdAt.toDate === "function"
-      ) {
-        dateObj = item.createdAt.toDate();
-      } else if (typeof item.createdAt === "number") {
-        // Fallback for Unix-Timestamps
-        dateObj = new Date(item.createdAt);
-      }
-    }
+    // set the date in the right format
+    const dateObj = normalizeCreatedAt(item.createdAt);
 
     // calculate the average item height to handle functionality of the scroll animation
     const mesureItemHeight = (event: LayoutChangeEvent) => {
       const { height } = event.nativeEvent.layout;
-      setAverageItemHeight(height);
+      setLastItemHeight(height);
     };
 
     return (

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -16,7 +16,6 @@ import {
   TextInput,
   TouchableOpacity,
   Animated,
-  LayoutChangeEvent,
   Dimensions,
   FlatList,
 } from "react-native";
@@ -33,15 +32,12 @@ import Modal from "react-native-modal";
 import { doc, getDoc } from "firebase/firestore";
 import { getAuth, Auth } from "firebase/auth";
 import { LinearGradient } from "expo-linear-gradient";
-import { AntDesign } from "@expo/vector-icons";
 import { MaterialIcons } from "@expo/vector-icons";
-import dayjs from "dayjs";
 import {
   CopilotProvider,
   CopilotStep,
   walkthroughable,
 } from "react-native-copilot";
-import * as Animatable from "react-native-animatable";
 
 import {
   FIREBASE_FIRESTORE,
@@ -49,6 +45,11 @@ import {
   FIREBASE_APP,
 } from "../firebaseConfig";
 import { RootStackParamList } from "../navigation/RootStackParams";
+import {
+  fetchProjects,
+  deleteProject,
+  createProject,
+} from "../services/projects.api";
 import ProjectListItem from "../components/projectListItem";
 import { Project } from "../components/types/Project";
 import { sortProjects } from "../components/utils/sortProjects";
@@ -64,9 +65,7 @@ import { useAlertStore } from "../components/services/customAlert/alertStore";
 import { useDotAnimation } from "../components/DotAnimation";
 import { sanitizeTitle } from "../components/InputSanitizers";
 import SortModal from "../components/SortModal";
-import { normalizeCreatedAt } from "../components/helper/normalizeCreatedAt.helper";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
-import { projectsAndWorkValidatorCallable } from "../firebase/functions";
 import { logError } from "../lib/loggerClient";
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -84,15 +83,6 @@ const WalkthroughTouchableOpacity = walkthroughable(TouchableOpacity);
 
 // definition of the walkthroughable component to handle the copilot with (View)
 const CopilotView = walkthroughable(View);
-
-// function to unwrap the body
-const unwrapBody = (body: any): any => {
-  if (body && typeof body === "object" && "result" in body) {
-    return body.result;
-  }
-
-  return body;
-};
 
 const HomeScreen: React.FC = () => {
   // initialize the copilot offset
@@ -153,29 +143,6 @@ const HomeScreen: React.FC = () => {
   const sortedProjects = React.useMemo(() => {
     return sortProjects(projects, sortOrder);
   }, [projects, sortOrder]);
-
-  // const sortedProjects = React.useMemo(() => {
-  //   return [...projects].sort((a, b) => {
-  //     const aDate = normalizeCreatedAt(a.createdAt);
-  //     const bDate = normalizeCreatedAt(b.createdAt);
-
-  //     const aTime = aDate ? aDate.getTime() : 0;
-  //     const bTime = bDate ? bDate.getTime() : 0;
-
-  //     switch (sortOrder) {
-  //       case "DATE_DESC":
-  //         return bTime - aTime;
-  //       case "DATE_ASC":
-  //         return aTime - bTime;
-  //       case "NAME_ASC":
-  //         return a.name.localeCompare(b.name);
-  //       case "NAME_DESC":
-  //         return b.name.localeCompare(a.name);
-  //       default:
-  //         return 0;
-  //     }
-  //   });
-  // }, [projects, sortOrder]);
 
   // ref to handle the flatlist scroll animation and refresh the projects list
   const flatListRef = React.useRef<FlatList>(null);
@@ -261,7 +228,7 @@ const HomeScreen: React.FC = () => {
 
     let active = true;
 
-    const fetchProjects = async () => {
+    const loadProjects = async () => {
       const user = FIREBASE_AUTH.currentUser;
 
       if (!serviceId || !user) {
@@ -277,25 +244,11 @@ const HomeScreen: React.FC = () => {
       setIsLoading(true);
 
       try {
-        const res = await projectsAndWorkValidatorCallable({
-          action: "getProjects",
-          payload: {
-            serviceId,
-          },
-        });
-
-        const body = unwrapBody(res.data);
+        const projects = await fetchProjects(serviceId);
 
         if (!active) return;
 
-        setProjects(
-          (body?.projects ?? []).map((project: any) => ({
-            id: project.id,
-            ...project,
-            name: project.name ?? "",
-            createdAt: normalizeCreatedAt(project.createdAt),
-          })),
-        );
+        setProjects(projects);
       } catch (err) {
         logError("HomeScreen/fetchProjects", err);
       } finally {
@@ -303,7 +256,7 @@ const HomeScreen: React.FC = () => {
       }
     };
 
-    fetchProjects();
+    loadProjects();
 
     return () => {
       active = false;
@@ -341,15 +294,7 @@ const HomeScreen: React.FC = () => {
     }
 
     try {
-      const res = await projectsAndWorkValidatorCallable({
-        action: "createProject",
-        payload: {
-          name: trimmedName,
-          serviceId,
-        },
-      });
-
-      const data = unwrapBody(res.data);
+      const data = await createProject(serviceId, trimmedName);
 
       const projectForState = {
         id: data.projectId,
@@ -404,13 +349,7 @@ const HomeScreen: React.FC = () => {
                   await ref.zoomOut(300);
                 }
 
-                await projectsAndWorkValidatorCallable({
-                  action: "deleteProject",
-                  payload: {
-                    projectId,
-                    serviceId,
-                  },
-                });
+                await deleteProject(serviceId, projectId);
 
                 setProjects((prev) => prev.filter((p) => p.id !== projectId));
 
@@ -474,166 +413,6 @@ const HomeScreen: React.FC = () => {
     ),
     [scrollY, accessMode],
   );
-
-  // const renderItem = ({ item, index }: { item: Project; index: number }) => {
-  //   // calculate animation
-  //   const inputRange = [
-  //     -1,
-  //     0,
-  //     ITEM_HEIGHT * index,
-  //     ITEM_HEIGHT * (index + 1),
-  //     ITEM_HEIGHT * (index + 2),
-  //   ];
-
-  //   const scale = scrollY.interpolate({
-  //     inputRange,
-  //     outputRange: [1, 1, 1, 0.8, 0.8],
-  //     extrapolate: "clamp",
-  //   });
-
-  //   const opacity = scrollY.interpolate({
-  //     inputRange,
-  //     outputRange: [1, 1, 1, 0.5, 0],
-  //     extrapolate: "clamp",
-  //   });
-
-  //   // set the date in the right format
-  //   const dateObj = normalizeCreatedAt(item.createdAt);
-
-  //   // calculate the average item height to handle functionality of the scroll animation
-  //   const mesureItemHeight = (event: LayoutChangeEvent) => {
-  //     const { height } = event.nativeEvent.layout;
-  //     setLastItemHeight(height);
-  //   };
-
-  //   return (
-  //     // add and delete  project card animation
-  //     <Animatable.View
-  //       animation="zoomInUp"
-  //       duration={1500}
-  //       delay={index * 100}
-  //       useNativeDriver
-  //       // ref to animate the project deleting
-  //       ref={(ref) => {
-  //         if (ref && item.id) {
-  //           animationRefs.current[item.id] = ref;
-  //         }
-  //       }}
-  //     >
-  //       {/* Animation View parameters */}
-  //       <Animated.View
-  //         style={{
-  //           height: ITEM_HEIGHT,
-  //           transform: [{ scale }],
-  //           opacity,
-  //           margin: 5,
-  //           flexDirection: "row",
-  //           justifyContent: "space-between",
-  //           alignItems: "center",
-  //           borderWidth: 1,
-  //           borderColor: "aqua",
-  //           minWidth: "98%",
-  //           backgroundColor: "#191919",
-  //           borderRadius: 8,
-  //         }}
-  //         onLayout={mesureItemHeight}
-  //       >
-  //         {/* Button to navigate to the details screen */}
-  //         <TouchableOpacity
-  //           onPress={() => handleProjectPress(item.id as string, item.name)}
-  //           accessibilityRole="button"
-  //           accessibilityLabel={`Project ${item.name}, created on ${
-  //             dateObj ? dayjs(dateObj).format("DD MMMM YYYY") : "unknown date"
-  //           }`}
-  //           accessibilityHint="Tap to view project details"
-  //           style={{ alignItems: "center", justifyContent: "center", flex: 1 }}
-  //         >
-  //           <View
-  //             style={{
-  //               height: "100%",
-  //               width: "100%",
-  //             }}
-  //           >
-  //             {/* Section with date in the project container */}
-  //             {dateObj ? (
-  //               <Text
-  //                 style={{
-  //                   color: accessMode ? "white" : "grey",
-  //                   fontSize: accessMode ? 16 : 13,
-  //                   paddingLeft: 10,
-  //                   marginTop: 5,
-  //                 }}
-  //               >
-  //                 {dayjs(dateObj).format("DD.MM.YYYY")}
-  //               </Text>
-  //             ) : (
-  //               <Text
-  //                 style={{
-  //                   color: "gray",
-  //                   fontSize: 13,
-  //                   paddingLeft: 10,
-  //                   marginTop: 5,
-  //                   fontStyle: "italic",
-  //                 }}
-  //               >
-  //                 No date available
-  //               </Text>
-  //             )}
-
-  //             {/* Project name in the project container */}
-  //             <Text
-  //               style={{
-  //                 marginTop: 5,
-  //                 marginLeft: 30,
-  //                 fontSize: accessMode ? 28 : 24,
-  //                 fontFamily: "MPLUSLatin_Bold",
-  //                 color: "white",
-  //               }}
-  //             >
-  //               {item.name}
-  //             </Text>
-  //           </View>
-  //         </TouchableOpacity>
-  //         <View
-  //           style={{
-  //             flexDirection: "column",
-  //             alignItems: "center",
-  //             justifyContent: "space-evenly",
-  //             marginRight: 10,
-  //             height: "100%",
-  //           }}
-  //         >
-  //           {/* Button to delete a project */}
-  //           <TouchableOpacity
-  //             onPress={() => handleDeleteProject(item.id)}
-  //             accessibilityRole="button"
-  //             accessibilityLabel="Delete the project"
-  //             accessibilityHint="Delete the project"
-  //           >
-  //             <AntDesign
-  //               name="delete"
-  //               size={30}
-  //               color={accessMode ? "white" : "darkgrey"}
-  //             />
-  //           </TouchableOpacity>
-  //           {/* Button to add a note to a project */}
-  //           <TouchableOpacity
-  //             onPress={() => openNoteModal(item.id)}
-  //             accessibilityRole="button"
-  //             accessibilityLabel="Add a note"
-  //             accessibilityHint="Add a note. You can watch it in the details screen"
-  //           >
-  //             <MaterialIcons
-  //               name="edit-note"
-  //               size={30}
-  //               color={accessMode ? "white" : "darkgrey"}
-  //             />
-  //           </TouchableOpacity>
-  //         </View>
-  //       </Animated.View>
-  //     </Animatable.View>
-  //   );
-  // };
 
   // hook to check Firestore if the user has seen the Copilot home tour
   const fetchTourStatus = async () => {

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -46,9 +46,9 @@ import {
 } from "../firebaseConfig";
 import { RootStackParamList } from "../navigation/RootStackParams";
 import {
-  fetchProjects,
-  deleteProject,
-  createProject,
+  fetchProjects as fetchProjectsApi,
+  deleteProject as deleteProjectApi,
+  createProject as createProjectApi,
 } from "../services/projects.api";
 import ProjectListItem from "../components/projectListItem";
 import { Project } from "../components/types/Project";
@@ -244,7 +244,7 @@ const HomeScreen: React.FC = () => {
       setIsLoading(true);
 
       try {
-        const projects = await fetchProjects(serviceId);
+        const projects = await fetchProjectsApi(serviceId);
 
         if (!active) return;
 
@@ -294,7 +294,7 @@ const HomeScreen: React.FC = () => {
     }
 
     try {
-      const data = await createProject(serviceId, trimmedName);
+      const data = await createProjectApi(serviceId, trimmedName);
 
       const projectForState = {
         id: data.projectId,
@@ -349,7 +349,7 @@ const HomeScreen: React.FC = () => {
                   await ref.zoomOut(300);
                 }
 
-                await deleteProject(serviceId, projectId);
+                await deleteProjectApi(serviceId, projectId);
 
                 setProjects((prev) => prev.filter((p) => p.id !== projectId));
 

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -51,6 +51,7 @@ import {
 import { RootStackParamList } from "../navigation/RootStackParams";
 import ProjectListItem from "../components/projectListItem";
 import { Project } from "../components/types/Project";
+import { sortProjects } from "../components/utils/sortProjects";
 import { useStore } from "../components/TimeTrackingState";
 import NoteModal from "../components/NoteModal";
 import RoutingLoader from "../components/RoutingLoader";
@@ -128,7 +129,7 @@ const HomeScreen: React.FC = () => {
   // initialize the project id globally to reset all components in the details screen
   const { setProjectId } = useStore();
 
-  // handle project state with props title, id and name
+  // handle project state with props title, id, name and createdAt
   const [projects, setProjects] = useState<Project[]>([]);
 
   // new project name state
@@ -136,6 +137,9 @@ const HomeScreen: React.FC = () => {
 
   // state to handel sort modal
   const [sortModalVisible, setSortModalVisible] = useState(false);
+
+  // sort order state
+  const [sortOrder, setSortOrder] = useState("DATE_DESC");
 
   const openSortModal = () => {
     setSortModalVisible(true);
@@ -145,32 +149,33 @@ const HomeScreen: React.FC = () => {
     setSortModalVisible(false);
   };
 
-  // sort order state
-  const [sortOrder, setSortOrder] = useState("DATE_DESC");
-
   // function to sort the projects
   const sortedProjects = React.useMemo(() => {
-    return [...projects].sort((a, b) => {
-      const aDate = normalizeCreatedAt(a.createdAt);
-      const bDate = normalizeCreatedAt(b.createdAt);
-
-      const aTime = aDate ? aDate.getTime() : 0;
-      const bTime = bDate ? bDate.getTime() : 0;
-
-      switch (sortOrder) {
-        case "DATE_DESC":
-          return bTime - aTime;
-        case "DATE_ASC":
-          return aTime - bTime;
-        case "NAME_ASC":
-          return a.name.localeCompare(b.name);
-        case "NAME_DESC":
-          return b.name.localeCompare(a.name);
-        default:
-          return 0;
-      }
-    });
+    return sortProjects(projects, sortOrder);
   }, [projects, sortOrder]);
+
+  // const sortedProjects = React.useMemo(() => {
+  //   return [...projects].sort((a, b) => {
+  //     const aDate = normalizeCreatedAt(a.createdAt);
+  //     const bDate = normalizeCreatedAt(b.createdAt);
+
+  //     const aTime = aDate ? aDate.getTime() : 0;
+  //     const bTime = bDate ? bDate.getTime() : 0;
+
+  //     switch (sortOrder) {
+  //       case "DATE_DESC":
+  //         return bTime - aTime;
+  //       case "DATE_ASC":
+  //         return aTime - bTime;
+  //       case "NAME_ASC":
+  //         return a.name.localeCompare(b.name);
+  //       case "NAME_DESC":
+  //         return b.name.localeCompare(a.name);
+  //       default:
+  //         return 0;
+  //     }
+  //   });
+  // }, [projects, sortOrder]);
 
   // ref to handle the flatlist scroll animation and refresh the projects list
   const flatListRef = React.useRef<FlatList>(null);

--- a/Screens/HomeScreen.tsx
+++ b/Screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-///////////////////////////////////// HomeSceen Component////////////////////////////////////////////
+///////////////////////////////////// HomeSceen Component ////////////////////////////////////////////
 
 // This component shows a list of projects and enabled the user to add and delete his projects.
 // The user can also write notes to every project in the list wich is also visible in the DetailsScreen.
@@ -49,6 +49,8 @@ import {
   FIREBASE_APP,
 } from "../firebaseConfig";
 import { RootStackParamList } from "../navigation/RootStackParams";
+import ProjectListItem from "../components/projectListItem";
+import { Project } from "../components/types/Project";
 import { useStore } from "../components/TimeTrackingState";
 import NoteModal from "../components/NoteModal";
 import RoutingLoader from "../components/RoutingLoader";
@@ -73,13 +75,6 @@ type HomeScreenRouteProp = RouteProp<
 >;
 
 type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList>;
-
-interface Project {
-  id: string;
-  name: string;
-  createdAt: Date | null;
-  [key: string]: any;
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -449,166 +444,191 @@ const HomeScreen: React.FC = () => {
   // define the dot animation with a delay
   const dots = useDotAnimation(loading, 700);
 
+  // initialize the accessibility store
+  const accessMode = useAccessibilityStore(
+    (state) => state.accessibilityEnabled,
+  );
+
   // scroll animation with parameters to handle the scroll animation
-  const renderItem = ({ item, index }: { item: Project; index: number }) => {
-    // calculate animation
-    const inputRange = [
-      -1,
-      0,
-      ITEM_HEIGHT * index,
-      ITEM_HEIGHT * (index + 1),
-      ITEM_HEIGHT * (index + 2),
-    ];
-
-    const scale = scrollY.interpolate({
-      inputRange,
-      outputRange: [1, 1, 1, 0.8, 0.8],
-      extrapolate: "clamp",
-    });
-
-    const opacity = scrollY.interpolate({
-      inputRange,
-      outputRange: [1, 1, 1, 0.5, 0],
-      extrapolate: "clamp",
-    });
-
-    // set the date in the right format
-    const dateObj = normalizeCreatedAt(item.createdAt);
-
-    // calculate the average item height to handle functionality of the scroll animation
-    const mesureItemHeight = (event: LayoutChangeEvent) => {
-      const { height } = event.nativeEvent.layout;
-      setLastItemHeight(height);
-    };
-
-    return (
-      // add and delete  project card animation
-      <Animatable.View
-        animation="zoomInUp"
-        duration={1500}
-        delay={index * 100}
-        useNativeDriver
-        // ref to animate the project deleting
-        ref={(ref) => {
-          if (ref && item.id) {
-            animationRefs.current[item.id] = ref;
-          }
+  const renderItem = React.useCallback(
+    ({ item, index }: { item: Project; index: number }) => (
+      <ProjectListItem
+        item={item}
+        index={index}
+        ITEM_HEIGHT={ITEM_HEIGHT}
+        scrollY={scrollY}
+        accessMode={accessMode}
+        animationRef={(id, ref) => {
+          if (ref) animationRefs.current[id] = ref;
         }}
-      >
-        {/* Animation View parameters */}
-        <Animated.View
-          style={{
-            height: ITEM_HEIGHT,
-            transform: [{ scale }],
-            opacity,
-            margin: 5,
-            flexDirection: "row",
-            justifyContent: "space-between",
-            alignItems: "center",
-            borderWidth: 1,
-            borderColor: "aqua",
-            minWidth: "98%",
-            backgroundColor: "#191919",
-            borderRadius: 8,
-          }}
-          onLayout={mesureItemHeight}
-        >
-          {/* Button to navigate to the details screen */}
-          <TouchableOpacity
-            onPress={() => handleProjectPress(item.id as string, item.name)}
-            accessibilityRole="button"
-            accessibilityLabel={`Project ${item.name}, created on ${
-              dateObj ? dayjs(dateObj).format("DD MMMM YYYY") : "unknown date"
-            }`}
-            accessibilityHint="Tap to view project details"
-            style={{ alignItems: "center", justifyContent: "center", flex: 1 }}
-          >
-            <View
-              style={{
-                height: "100%",
-                width: "100%",
-              }}
-            >
-              {/* Section with date in the project container */}
-              {dateObj ? (
-                <Text
-                  style={{
-                    color: accessMode ? "white" : "grey",
-                    fontSize: accessMode ? 16 : 13,
-                    paddingLeft: 10,
-                    marginTop: 5,
-                  }}
-                >
-                  {dayjs(dateObj).format("DD.MM.YYYY")}
-                </Text>
-              ) : (
-                <Text
-                  style={{
-                    color: "gray",
-                    fontSize: 13,
-                    paddingLeft: 10,
-                    marginTop: 5,
-                    fontStyle: "italic",
-                  }}
-                >
-                  No date available
-                </Text>
-              )}
+        onPress={handleProjectPress}
+        onDelete={handleDeleteProject}
+        onAddNote={openNoteModal}
+        setLastItemHeight={setLastItemHeight}
+      />
+    ),
+    [scrollY, accessMode],
+  );
 
-              {/* Project name in the project container */}
-              <Text
-                style={{
-                  marginTop: 5,
-                  marginLeft: 30,
-                  fontSize: accessMode ? 28 : 24,
-                  fontFamily: "MPLUSLatin_Bold",
-                  color: "white",
-                }}
-              >
-                {item.name}
-              </Text>
-            </View>
-          </TouchableOpacity>
-          <View
-            style={{
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "space-evenly",
-              marginRight: 10,
-              height: "100%",
-            }}
-          >
-            {/* Button to delete a project */}
-            <TouchableOpacity
-              onPress={() => handleDeleteProject(item.id)}
-              accessibilityRole="button"
-              accessibilityLabel="Delete the project"
-              accessibilityHint="Delete the project"
-            >
-              <AntDesign
-                name="delete"
-                size={30}
-                color={accessMode ? "white" : "darkgrey"}
-              />
-            </TouchableOpacity>
-            {/* Button to add a note to a project */}
-            <TouchableOpacity
-              onPress={() => openNoteModal(item.id)}
-              accessibilityRole="button"
-              accessibilityLabel="Add a note"
-              accessibilityHint="Add a note. You can watch it in the details screen"
-            >
-              <MaterialIcons
-                name="edit-note"
-                size={30}
-                color={accessMode ? "white" : "darkgrey"}
-              />
-            </TouchableOpacity>
-          </View>
-        </Animated.View>
-      </Animatable.View>
-    );
-  };
+  // const renderItem = ({ item, index }: { item: Project; index: number }) => {
+  //   // calculate animation
+  //   const inputRange = [
+  //     -1,
+  //     0,
+  //     ITEM_HEIGHT * index,
+  //     ITEM_HEIGHT * (index + 1),
+  //     ITEM_HEIGHT * (index + 2),
+  //   ];
+
+  //   const scale = scrollY.interpolate({
+  //     inputRange,
+  //     outputRange: [1, 1, 1, 0.8, 0.8],
+  //     extrapolate: "clamp",
+  //   });
+
+  //   const opacity = scrollY.interpolate({
+  //     inputRange,
+  //     outputRange: [1, 1, 1, 0.5, 0],
+  //     extrapolate: "clamp",
+  //   });
+
+  //   // set the date in the right format
+  //   const dateObj = normalizeCreatedAt(item.createdAt);
+
+  //   // calculate the average item height to handle functionality of the scroll animation
+  //   const mesureItemHeight = (event: LayoutChangeEvent) => {
+  //     const { height } = event.nativeEvent.layout;
+  //     setLastItemHeight(height);
+  //   };
+
+  //   return (
+  //     // add and delete  project card animation
+  //     <Animatable.View
+  //       animation="zoomInUp"
+  //       duration={1500}
+  //       delay={index * 100}
+  //       useNativeDriver
+  //       // ref to animate the project deleting
+  //       ref={(ref) => {
+  //         if (ref && item.id) {
+  //           animationRefs.current[item.id] = ref;
+  //         }
+  //       }}
+  //     >
+  //       {/* Animation View parameters */}
+  //       <Animated.View
+  //         style={{
+  //           height: ITEM_HEIGHT,
+  //           transform: [{ scale }],
+  //           opacity,
+  //           margin: 5,
+  //           flexDirection: "row",
+  //           justifyContent: "space-between",
+  //           alignItems: "center",
+  //           borderWidth: 1,
+  //           borderColor: "aqua",
+  //           minWidth: "98%",
+  //           backgroundColor: "#191919",
+  //           borderRadius: 8,
+  //         }}
+  //         onLayout={mesureItemHeight}
+  //       >
+  //         {/* Button to navigate to the details screen */}
+  //         <TouchableOpacity
+  //           onPress={() => handleProjectPress(item.id as string, item.name)}
+  //           accessibilityRole="button"
+  //           accessibilityLabel={`Project ${item.name}, created on ${
+  //             dateObj ? dayjs(dateObj).format("DD MMMM YYYY") : "unknown date"
+  //           }`}
+  //           accessibilityHint="Tap to view project details"
+  //           style={{ alignItems: "center", justifyContent: "center", flex: 1 }}
+  //         >
+  //           <View
+  //             style={{
+  //               height: "100%",
+  //               width: "100%",
+  //             }}
+  //           >
+  //             {/* Section with date in the project container */}
+  //             {dateObj ? (
+  //               <Text
+  //                 style={{
+  //                   color: accessMode ? "white" : "grey",
+  //                   fontSize: accessMode ? 16 : 13,
+  //                   paddingLeft: 10,
+  //                   marginTop: 5,
+  //                 }}
+  //               >
+  //                 {dayjs(dateObj).format("DD.MM.YYYY")}
+  //               </Text>
+  //             ) : (
+  //               <Text
+  //                 style={{
+  //                   color: "gray",
+  //                   fontSize: 13,
+  //                   paddingLeft: 10,
+  //                   marginTop: 5,
+  //                   fontStyle: "italic",
+  //                 }}
+  //               >
+  //                 No date available
+  //               </Text>
+  //             )}
+
+  //             {/* Project name in the project container */}
+  //             <Text
+  //               style={{
+  //                 marginTop: 5,
+  //                 marginLeft: 30,
+  //                 fontSize: accessMode ? 28 : 24,
+  //                 fontFamily: "MPLUSLatin_Bold",
+  //                 color: "white",
+  //               }}
+  //             >
+  //               {item.name}
+  //             </Text>
+  //           </View>
+  //         </TouchableOpacity>
+  //         <View
+  //           style={{
+  //             flexDirection: "column",
+  //             alignItems: "center",
+  //             justifyContent: "space-evenly",
+  //             marginRight: 10,
+  //             height: "100%",
+  //           }}
+  //         >
+  //           {/* Button to delete a project */}
+  //           <TouchableOpacity
+  //             onPress={() => handleDeleteProject(item.id)}
+  //             accessibilityRole="button"
+  //             accessibilityLabel="Delete the project"
+  //             accessibilityHint="Delete the project"
+  //           >
+  //             <AntDesign
+  //               name="delete"
+  //               size={30}
+  //               color={accessMode ? "white" : "darkgrey"}
+  //             />
+  //           </TouchableOpacity>
+  //           {/* Button to add a note to a project */}
+  //           <TouchableOpacity
+  //             onPress={() => openNoteModal(item.id)}
+  //             accessibilityRole="button"
+  //             accessibilityLabel="Add a note"
+  //             accessibilityHint="Add a note. You can watch it in the details screen"
+  //           >
+  //             <MaterialIcons
+  //               name="edit-note"
+  //               size={30}
+  //               color={accessMode ? "white" : "darkgrey"}
+  //             />
+  //           </TouchableOpacity>
+  //         </View>
+  //       </Animated.View>
+  //     </Animatable.View>
+  //   );
+  // };
 
   // hook to check Firestore if the user has seen the Copilot home tour
   const fetchTourStatus = async () => {
@@ -655,11 +675,6 @@ const HomeScreen: React.FC = () => {
   const EmptyStepNumber = () => {
     return null;
   };
-
-  // initialize the accessibility store
-  const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled,
-  );
 
   return (
     <DismissKeyboard>

--- a/components/SortModal.tsx
+++ b/components/SortModal.tsx
@@ -44,7 +44,7 @@ const SortModalFAB = ({
   // hook to announce accessibility
   useEffect(() => {
     AccessibilityInfo.announceForAccessibility(
-      "Sort Modal opened. Please select a sort option."
+      "Sort Modal opened. Please select a sort option.",
     );
   }, []);
 
@@ -73,9 +73,8 @@ const SortModalFAB = ({
 
   // initialize the accessibility store
   const accessMode = useAccessibilityStore(
-    (state) => state.accessibilityEnabled
+    (state) => state.accessibilityEnabled,
   );
-  // console.log("accessMode in LoginScreen:", accessMode);
 
   return (
     <View

--- a/components/helper/normalizeCreatedAt.helper.ts
+++ b/components/helper/normalizeCreatedAt.helper.ts
@@ -14,6 +14,15 @@ export const normalizeCreatedAt = (value: unknown): Date | null => {
     return (value as any).toDate();
   }
 
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "_seconds" in value &&
+    typeof (value as any)._seconds === "number"
+  ) {
+    return new Date((value as any)._seconds * 1000);
+  }
+
   if (typeof value === "number") return new Date(value);
 
   const parsed = new Date(value as any);

--- a/components/helper/unwrapBody.ts
+++ b/components/helper/unwrapBody.ts
@@ -1,0 +1,13 @@
+///////////////////////// unwrapBody.ts //////////////////////////
+
+// This file is used to unwrap the body of the response from the firebase functions
+
+//////////////////////////////////////////////////////////////////
+
+export const unwrapBody = (body: any): any => {
+  if (body && typeof body === "object" && "result" in body) {
+    return body.result;
+  }
+
+  return body;
+};

--- a/components/projectListItem.tsx
+++ b/components/projectListItem.tsx
@@ -1,0 +1,202 @@
+///////////////////////////////// projectListItem.tsx //////////////////////////////
+
+// This component is used to show a list item of a project in the HomeScreen
+
+////////////////////////////////////////////////////////////////////////////////////
+
+import React from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Animated,
+  LayoutChangeEvent,
+} from "react-native";
+import * as Animatable from "react-native-animatable";
+import { AntDesign, MaterialIcons } from "@expo/vector-icons";
+import dayjs from "dayjs";
+
+import { normalizeCreatedAt } from "../components/helper/normalizeCreatedAt.helper";
+import { Project } from "../components/types/Project";
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+type Props = {
+  item: Project;
+  index: number;
+
+  ITEM_HEIGHT: number;
+  scrollY: Animated.Value;
+
+  accessMode: boolean;
+
+  animationRef: (id: string, ref: any) => void;
+
+  onPress: (id: string, name: string) => void;
+  onDelete: (id: string) => void;
+  onAddNote: (id: string) => void;
+
+  setLastItemHeight: (h: number) => void;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////
+
+const ProjectListItem: React.FC<Props> = ({
+  item,
+  index,
+  ITEM_HEIGHT,
+  scrollY,
+  accessMode,
+  animationRef,
+  onPress,
+  onDelete,
+  onAddNote,
+  setLastItemHeight,
+}) => {
+  // calculate animation
+  const inputRange = [
+    -1,
+    0,
+    ITEM_HEIGHT * index,
+    ITEM_HEIGHT * (index + 1),
+    ITEM_HEIGHT * (index + 2),
+  ];
+
+  const scale = scrollY.interpolate({
+    inputRange,
+    outputRange: [1, 1, 1, 0.8, 0.8],
+    extrapolate: "clamp",
+  });
+
+  const opacity = scrollY.interpolate({
+    inputRange,
+    outputRange: [1, 1, 1, 0.5, 0],
+    extrapolate: "clamp",
+  });
+
+  // set the date in the right format
+  const dateObj = normalizeCreatedAt(item.createdAt);
+
+  // calculate the last item height to handle functionality of the scroll animation
+  const measureItemHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setLastItemHeight(height);
+  };
+
+  return (
+    // add and delete  project card animation
+    <Animatable.View
+      animation="zoomInUp"
+      duration={1500}
+      delay={index * 100}
+      useNativeDriver
+      // ref to animate the project deleting
+      ref={(ref) => {
+        if (ref && item.id) {
+          animationRef(item.id, ref);
+        }
+      }}
+    >
+      {/* Animation View parameters */}
+      <Animated.View
+        style={{
+          height: ITEM_HEIGHT,
+          transform: [{ scale }],
+          opacity,
+          margin: 5,
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "center",
+          borderWidth: 1,
+          borderColor: "aqua",
+          minWidth: "98%",
+          backgroundColor: "#191919",
+          borderRadius: 8,
+        }}
+        onLayout={measureItemHeight}
+      >
+        {/* LEFT SIDE */}
+        {/* Button to navigate to the details screen */}
+        <TouchableOpacity
+          onPress={() => onPress(item.id, item.name)}
+          accessibilityRole="button"
+          accessibilityLabel={`Project ${item.name}, created on ${
+            dateObj ? dayjs(dateObj).format("DD MMMM YYYY") : "unknown date"
+          }`}
+          accessibilityHint="Tap to view project details"
+          style={{ flex: 1 }}
+        >
+          <View style={{ height: "100%", width: "100%" }}>
+            {/* Section with date in the project container */}
+            {dateObj ? (
+              <Text
+                style={{
+                  color: accessMode ? "white" : "grey",
+                  fontSize: 14,
+                }}
+              >
+                {dayjs(dateObj).format("DD.MM.YYYY")}
+              </Text>
+            ) : (
+              <Text style={{ color: "gray", fontSize: 13 }}>
+                No date available
+              </Text>
+            )}
+            {/* Project name in the project container */}
+            <Text
+              style={{
+                marginTop: 5,
+                marginLeft: 30,
+                fontSize: accessMode ? 28 : 24,
+                fontFamily: "MPLUSLatin_Bold",
+                color: "white",
+              }}
+            >
+              {item.name}
+            </Text>
+          </View>
+        </TouchableOpacity>
+
+        {/* RIGHT SIDE */}
+        <View
+          style={{
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "space-evenly",
+            marginRight: 10,
+            height: "100%",
+          }}
+        >
+          {/* Button to delete a project */}
+          <TouchableOpacity
+            onPress={() => onDelete(item.id)}
+            accessibilityRole="button"
+            accessibilityLabel="Delete the project"
+            accessibilityHint="Delete the project"
+          >
+            <AntDesign
+              name="delete"
+              size={30}
+              color={accessMode ? "white" : "darkgrey"}
+            />
+          </TouchableOpacity>
+          {/* Button to add a note to a project */}
+          <TouchableOpacity
+            onPress={() => onAddNote(item.id)}
+            accessibilityRole="button"
+            accessibilityLabel="Add a note"
+            accessibilityHint="Add a note. You can watch it in the details screen"
+          >
+            <MaterialIcons
+              name="edit-note"
+              size={30}
+              color={accessMode ? "white" : "darkgrey"}
+            />
+          </TouchableOpacity>
+        </View>
+      </Animated.View>
+    </Animatable.View>
+  );
+};
+
+export default ProjectListItem;

--- a/components/types/Project.ts
+++ b/components/types/Project.ts
@@ -1,0 +1,11 @@
+//////////////////// Project.ts //////////////////////
+
+// This file is used to define the type of the project object in ProjectListItem.ts
+
+////////////////////////////////////////////////////////
+
+export interface Project {
+  id: string;
+  name: string;
+  createdAt: Date | null;
+}

--- a/components/utils/sortProjects.ts
+++ b/components/utils/sortProjects.ts
@@ -1,0 +1,40 @@
+///////////////////////////// sortProjects.ts //////////////////////////////
+
+// This file is used to sort the projects in the HomeScreen
+
+////////////////////////////////////////////////////////////////////////////
+
+import { normalizeCreatedAt } from "../helper/normalizeCreatedAt.helper";
+import { Project } from "../types/Project";
+
+////////////////////////////////////////////////////////////////////////////
+
+export function sortProjects(
+  projects: Project[],
+  sortOrder: string,
+): Project[] {
+  return [...projects].sort((a, b) => {
+    const aDate = normalizeCreatedAt(a.createdAt);
+    const bDate = normalizeCreatedAt(b.createdAt);
+
+    const aTime = aDate ? aDate.getTime() : 0;
+    const bTime = bDate ? bDate.getTime() : 0;
+
+    switch (sortOrder) {
+      case "DATE_DESC":
+        return bTime - aTime;
+
+      case "DATE_ASC":
+        return aTime - bTime;
+
+      case "NAME_ASC":
+        return a.name.localeCompare(b.name);
+
+      case "NAME_DESC":
+        return b.name.localeCompare(a.name);
+
+      default:
+        return 0;
+    }
+  });
+}

--- a/services/projects.api.ts
+++ b/services/projects.api.ts
@@ -1,0 +1,55 @@
+///////////////////////////// projects.api.ts //////////////////////////////
+
+// This file is used to define the api for the projects
+
+////////////////////////////////////////////////////////////////////////////
+
+import { normalizeCreatedAt } from "../components/helper/normalizeCreatedAt.helper";
+import { projectsAndWorkValidatorCallable } from "../firebase/functions";
+import { unwrapBody } from "../components/helper/unwrapBody";
+import { Project } from "../components/types/Project";
+
+////////////////////////////////////////////////////////////////////////////
+
+export async function fetchProjects(serviceId: string): Promise<Project[]> {
+  const res = await projectsAndWorkValidatorCallable({
+    action: "getProjects",
+    payload: {
+      serviceId,
+    },
+  });
+
+  const body = unwrapBody(res.data);
+
+  return (body?.projects ?? []).map((project: any) => ({
+    id: project.id,
+    ...project,
+    name: project.name ?? "",
+    createdAt: normalizeCreatedAt(project.createdAt),
+  }));
+}
+
+export async function createProject(
+  serviceId: string,
+  name: string,
+): Promise<{ projectId: string }> {
+  const res = await projectsAndWorkValidatorCallable({
+    action: "createProject",
+    payload: {
+      name,
+      serviceId,
+    },
+  });
+
+  return unwrapBody(res.data);
+}
+
+export async function deleteProject(serviceId: string, projectId: string) {
+  await projectsAndWorkValidatorCallable({
+    action: "deleteProject",
+    payload: {
+      projectId,
+      serviceId,
+    },
+  });
+}

--- a/services/projects.api.ts
+++ b/services/projects.api.ts
@@ -21,12 +21,13 @@ export async function fetchProjects(serviceId: string): Promise<Project[]> {
 
   const body = unwrapBody(res.data);
 
-  return (body?.projects ?? []).map((project: any) => ({
-    id: project.id,
-    ...project,
-    name: project.name ?? "",
-    createdAt: normalizeCreatedAt(project.createdAt),
-  }));
+  return (body?.projects ?? []).map(
+    (project: any): Project => ({
+      id: project.id,
+      name: project.name ?? "",
+      createdAt: normalizeCreatedAt(project.createdAt),
+    }),
+  );
 }
 
 export async function createProject(


### PR DESCRIPTION
## Title

### Refactor HomeScreen project handling into reusable components and services

## Type of Changes

- [ ] ✨ feat: New Feature
- [ ] 🐛 fix: Bugfix
- [x] 🔄 refactor: Code Refactoring
- [ ] 📖 docs: Documentation changes
- [ ] 🎨 style: Change rendering
- [ ] 🧪 test: Tests added or changed
- [x] 🔧 chore: Maintenance work
- [ ] 🎭 ui: UI changes

## Changes

- Extract project list item into `components/projectListItem.tsx`.
- Extract project API calls into `services/projects.api.ts`.
- Extract project sorting into `components/utils/sortProjects.ts`.
- Extract `unwrapBody` helper into `components/helper/unwrapBody.ts`.
- Extract shared `Project` type into `components/types/Project.ts`.
- Replace inline sorting logic with reusable `sortProjects()` utility.
- Replace inline Firebase callable logic with reusable API functions.
- Extend `normalizeCreatedAt()` to support Firestore `_seconds` timestamp objects.
- Remove duplicated utility code from `HomeScreen`.
- Keep `HomeScreen` as the orchestration component while moving reusable logic into dedicated files.

## Tests

- [x] ✅ Changes are tested
- [ ] 🚫 No tests necessary

## Files changed

- `Screens/HomeScreen.tsx` (refactored)
- `components/projectListItem.tsx` (added)
- `components/types/Project.ts` (added)
- `components/utils/sortProjects.ts` (added)
- `components/helper/unwrapBody.ts` (added)
- `components/helper/normalizeCreatedAt.helper.ts` (updated)
- `services/projects.api.ts` (added)
- `components/SortModal.tsx` (minor cleanup)

## Checklist

- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies

- None

## Notes

- This PR focuses on reducing the size and responsibility of `HomeScreen` without changing its overall architecture.
- Reusable logic has been extracted into dedicated helpers, services, utilities, and components while preserving the existing behavior.