### PR TITLE
refactor(sec): migrated adding ServiceId responsibility to backend

### DIFF
--- a/components/contexts/ServiceContext.tsx
+++ b/components/contexts/ServiceContext.tsx
@@ -5,20 +5,20 @@
 ////////////////////////////////////////////////////////////////////////////////////
 
 import React, { createContext, useContext, useState, useEffect } from "react";
-import { collection, getDocs, addDoc } from "firebase/firestore";
+import { collection, getDocs } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
 
 import { FIREBASE_FIRESTORE, FIREBASE_AUTH } from "../../firebaseConfig";
 import { logError } from "../../lib/loggerClient";
 
-// ////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////
 
 interface ServiceContextType {
   serviceId: string | null;
   loading: boolean;
 }
 
-// ////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////
 
 // Create the context
 const ServiceContext = createContext<ServiceContextType | undefined>(undefined);
@@ -31,8 +31,10 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(FIREBASE_AUTH, async (user) => {
-      if (!user) {
+    let active = true;
+
+    const run = async (user: any) => {
+      if (!user?.uid) {
         setServiceId(null);
         setLoading(false);
         return;
@@ -49,25 +51,33 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
         );
 
         const snapshot = await getDocs(servicesRef);
+        if (!active) return;
 
         if (snapshot.empty) {
-          const newServiceRef = await addDoc(servicesRef, {
-            createdAt: new Date(),
-          });
-
-          setServiceId(newServiceRef.id);
-        } else {
-          setServiceId(snapshot.docs[0].id);
+          setServiceId(null);
+          setLoading(true);
+          return;
         }
+
+        setServiceId(snapshot.docs[0].id);
+        setLoading(false);
       } catch (err) {
-        logError("ServiceContext/createService", err);
+        if (!active) return;
+
+        logError("ServiceContext/load", err);
         setServiceId(null);
-      } finally {
         setLoading(false);
       }
+    };
+
+    const unsub = onAuthStateChanged(FIREBASE_AUTH, (user) => {
+      run(user);
     });
 
-    return unsubscribe;
+    return () => {
+      active = false;
+      unsub();
+    };
   }, []);
 
   return (

--- a/components/contexts/ServiceContext.tsx
+++ b/components/contexts/ServiceContext.tsx
@@ -16,6 +16,7 @@ import { logError } from "../../lib/loggerClient";
 interface ServiceContextType {
   serviceId: string | null;
   loading: boolean;
+  ready: boolean;
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -29,6 +30,7 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [serviceId, setServiceId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -36,11 +38,13 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
     const run = async (user: any) => {
       if (!user?.uid) {
         setServiceId(null);
+        setReady(false);
         setLoading(false);
         return;
       }
 
       setLoading(true);
+      setReady(false);
 
       try {
         const servicesRef = collection(
@@ -51,21 +55,25 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
         );
 
         const snapshot = await getDocs(servicesRef);
+
         if (!active) return;
 
         if (snapshot.empty) {
           setServiceId(null);
-          setLoading(true);
+          setReady(false);
+          setLoading(false);
           return;
         }
 
         setServiceId(snapshot.docs[0].id);
+        setReady(true);
         setLoading(false);
       } catch (err) {
         if (!active) return;
 
         logError("ServiceContext/load", err);
         setServiceId(null);
+        setReady(false);
         setLoading(false);
       }
     };
@@ -81,7 +89,7 @@ export const ServiceProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   return (
-    <ServiceContext.Provider value={{ serviceId, loading }}>
+    <ServiceContext.Provider value={{ serviceId, loading, ready }}>
       {children}
     </ServiceContext.Provider>
   );

--- a/functions/src/repos/userRepo.ts
+++ b/functions/src/repos/userRepo.ts
@@ -32,6 +32,11 @@ export class UserRepo {
           hasSeenVacationTour: false,
           hasSeenWorkHoursTour: false,
         });
+
+        const serviceRef = ref.collection("Services").doc();
+        tx.set(serviceRef, {
+          createdAt: FieldValue.serverTimestamp(),
+        });
       }
     });
 


### PR DESCRIPTION
## Titel  
### Refactor ServiceContext serviceId loading + stabilize backend-owned service creation flow

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering  
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintenance work  
- [ ] 🎭 ui: Ui changes  

## Changes  
- Refactor `ServiceContext` authentication flow with stable async `run()` wrapper and cancellation guard (`active` flag).
- Remove client-side service creation via `addDoc` (service creation fully handled in backend transaction).
- Simplify Firestore read logic: `serviceId` is always derived from existing `Services` snapshot.
- Remove conditional service creation branch for empty snapshot.
- Add `ready` state to prevent premature consumption of `serviceId` before data is available.
- Fix cleanup logic of `onAuthStateChanged` subscription to prevent state updates after unmount.
- Standardize logging for ServiceContext load errors (`ServiceContext/load`).
- Align frontend with backend responsibility shift (`UserRepo.createUserIfNotExists` now owns service creation).

## Tests  
- [x] ✅ Changes are tested  
- [ ] 🚫 No tests necessary (covered by existing integration/emulator tests)

## Files changed 
- `components/contexts/ServiceContext.tsx` (modified)
- `functions/src/repos/userRepo.ts` (modified)

## Checklist
- [x] My changes are well-tested and commented
- [x] My changes generate no new warnings
- [x] I reviewed my changes

## Dependencies
- None

## Notes
- Service creation is fully backend-owned (transactional via `UserRepo`).
- Frontend only reads existing service documents.
- `ready` flag prevents race conditions between auth state and Firestore availability.
- Eliminates client-side race condition from service creation flow.document creation.