### PR TITLE
test (integration): stabilize Firebase emulator tests with cleanup and deterministic Jest execution

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "test:e2e": "npm run build && firebase emulators:exec --project demo-test --only firestore,auth,functions,storage \"jest --config=jest.e2e.config.js tests/e2e --runInBand\"",
     "test:unit": "jest --config=jest.unit.config.js",
     "test:race": "firebase emulators:exec --project demo-test --only firestore,auth,functions,storage \"jest --config jest.race.config.js --runInBand\"",
-    "test:integration": "firebase emulators:exec --project demo-test --only functions,auth,firestore,storage \"jest --config=jest.integration.config.js\"",
+    "test:integration": "firebase emulators:exec --project demo-test --only functions,auth,firestore,storage \".\\node_modules\\.bin\\jest --config=jest.integration.config.js --runInBand --forceExit\"",
     "test:integration:user": "jest tests/integration/repos/userRepo.integration.ts --config=jest.integration.config.js",
     "emulators": "firebase emulators:start --only firestore,auth --project=test-project"
   },

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,7 +9,7 @@
     "test:e2e": "npm run build && firebase emulators:exec --project demo-test --only firestore,auth,functions,storage \"jest --config=jest.e2e.config.js tests/e2e --runInBand\"",
     "test:unit": "jest --config=jest.unit.config.js",
     "test:race": "firebase emulators:exec --project demo-test --only firestore,auth,functions,storage \"jest --config jest.race.config.js --runInBand\"",
-    "test:integration": "firebase emulators:exec --project demo-test --only functions,auth,firestore,storage \".\\node_modules\\.bin\\jest --config=jest.integration.config.js --runInBand --forceExit\"",
+    "test:integration": "firebase emulators:exec --project demo-test --only functions,auth,firestore,storage \"npm exec jest -- --config=jest.integration.config.js --runInBand --forceExit\"",
     "test:integration:user": "jest tests/integration/repos/userRepo.integration.ts --config=jest.integration.config.js",
     "emulators": "firebase emulators:start --only firestore,auth --project=test-project"
   },

--- a/functions/tests/integration.setup.ts
+++ b/functions/tests/integration.setup.ts
@@ -18,7 +18,7 @@ if (!process.env.FIREBASE_AUTH_EMULATOR_HOST) {
 if (!process.env.FIREBASE_STORAGE_EMULATOR_HOST) {
   process.env.FIREBASE_STORAGE_EMULATOR_HOST = "localhost:9199";
 }
-process.env.GCLOUD_PROJECT = "test-project";
+process.env.GCLOUD_PROJECT = "demo-test";
 
 process.env.NODE_ENV = "test";
 process.env.RATE_LIMIT_DISABLED = "true";
@@ -26,8 +26,13 @@ process.env.RATE_LIMIT_HMAC_KEY = "test-hmac-key";
 
 // Firebase Admin init (idempotent)
 if (!admin.apps.length) {
-  admin.initializeApp({ projectId: "test-project" });
+  admin.initializeApp({ projectId: "demo-test" });
 }
+
+// cleanup
+afterAll(async () => {
+  await Promise.all(admin.apps.map((app) => app?.delete()));
+});
 
 // Silence logger output during integration tests.
 // Logging itself is not under test here and expected error paths


### PR DESCRIPTION
## Titel   
### Stabilize Firebase integration tests — cleanup handling + deterministic Jest execution

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [ ] 🎭 ui: Ui changes  

## Changes  
- Fix Firebase Admin SDK cleanup in integration test setup.
- Add explicit Firebase app cleanup after integration test execution.
- Adjust Jest integration test execution to run sequentially with `--runInBand`.
- Add `--forceExit` for Firebase emulator integration tests to prevent hanging Jest processes caused by remaining async handles.
- Align Firebase Admin SDK project configuration with emulator project (`demo-test`).

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed 
- `tests/integration.setup.ts` (updated)
- `package.json` (updated)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies
No dependency changes.

## Notes
- Integration tests now execute reliably with Firebase Emulators.
- Remaining Jest open handle warnings were caused by Firebase/Emulator lifecycle behavior and are handled through explicit integration test execution settings.