### PR TITLE
feat (workhours-chart): add selectable year view and include year in tooltip dates

### DIFF
--- a/components/FormatToolTip.ts
+++ b/components/FormatToolTip.ts
@@ -6,14 +6,14 @@
 
 export const formatTooltipDate = (
   dateString?: string,
-  chartType?: string
+  chartType?: string,
 ): string => {
   if (!dateString) return "No date available";
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return "unknown date";
   // condition: if the chart type is "year" only show the month
   if (chartType === "year") {
-    return date.toLocaleDateString("en-GB", { month: "long" });
+    return date.toLocaleDateString("en-GB", { month: "long", year: "numeric" });
   }
   return `${date.toLocaleDateString("en-GB", { weekday: "long" })}\n${date.toLocaleDateString("en-GB", { day: "2-digit", month: "long" })}`;
 };

--- a/components/WorkHoursChart.tsx
+++ b/components/WorkHoursChart.tsx
@@ -19,6 +19,7 @@ import { CopilotStep, walkthroughable } from "react-native-copilot";
 
 import WorkHoursState from "../components/WorkHoursState";
 import ChartRadioButtons from "./ChartRadioButtons";
+import YearSelector from "./YearSelector";
 import { formatTooltipDate } from "../components/FormatToolTip";
 import { formatTime } from "../components/WorkTimeCalc";
 import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
@@ -124,6 +125,9 @@ const WorkHoursChart = () => {
     }
   };
 
+  // state to hold the selected year
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+
   // function to filter data by chart type
   const filterDataByChartType = (data: any, type: string) => {
     // get the current date
@@ -158,7 +162,7 @@ const WorkHoursChart = () => {
         );
         // condition to check the chart type
       } else if (type === "year") {
-        return itemDate.getFullYear() === today.getFullYear();
+        return itemDate.getFullYear() === selectedYear;
       }
       return false;
     });
@@ -313,6 +317,11 @@ const WorkHoursChart = () => {
     return Math.max(1, rounded);
   };
 
+  // function to calculate the available years
+  const availableYears = [
+    ...new Set(data.map((item) => new Date(item.workDay).getFullYear())),
+  ].sort((a, b) => b - a);
+
   // use the getDynamicMaxValue function
   const dynamicMaxValue = getDynamicMaxValue();
   // calculate the number of sections for the Y-Axis
@@ -368,6 +377,14 @@ const WorkHoursChart = () => {
                   setTooltipData(null); // close tooltip if chart type changes
                 }}
               />
+
+              {chartType === "year" && (
+                <YearSelector
+                  years={availableYears}
+                  selectedYear={selectedYear}
+                  onChange={setSelectedYear}
+                />
+              )}
               {/* Frame-Container with horizontal scrollbar */}
               <View style={{ paddingHorizontal: cardPadding }}>
                 {/* Horizontal scrollbarer container for the BarChart */}

--- a/components/YearSelector.tsx
+++ b/components/YearSelector.tsx
@@ -1,0 +1,133 @@
+////////////////////////////////// YearSelector Component ////////////////////////////////
+
+// This component is used to select the year in the WorkHours Chart year view
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+
+import { useAccessibilityStore } from "../components/services/accessibility/accessibilityStore";
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+interface YearSelectorProps {
+  years: number[];
+  selectedYear: number;
+  onChange: (year: number) => void;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+const YearSelector: React.FC<YearSelectorProps> = ({
+  years,
+  selectedYear,
+  onChange,
+}) => {
+  const accessMode = useAccessibilityStore(
+    (state) => state.accessibilityEnabled,
+  );
+
+  const currentIndex = years.indexOf(selectedYear);
+
+  const selectPreviousYear = () => {
+    if (currentIndex < years.length - 1) {
+      onChange(years[currentIndex + 1]);
+    }
+  };
+
+  const selectNextYear = () => {
+    if (currentIndex > 0) {
+      onChange(years[currentIndex - 1]);
+    }
+  };
+
+  return (
+    <View
+      style={{
+        alignItems: "center",
+        marginBottom: 20,
+      }}
+    >
+      <Text
+        style={{
+          color: "white",
+          fontSize: accessMode ? 18 : 16,
+          fontWeight: "bold",
+          marginBottom: 8,
+        }}
+      >
+        Year
+      </Text>
+
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <TouchableOpacity
+          onPress={selectPreviousYear}
+          disabled={currentIndex >= years.length - 1}
+          style={{
+            paddingHorizontal: 15,
+            paddingVertical: 5,
+          }}
+        >
+          <Text
+            style={{
+              color: currentIndex >= years.length - 1 ? "gray" : "aqua",
+              fontSize: 24,
+            }}
+          >
+            ◀
+          </Text>
+        </TouchableOpacity>
+
+        <View
+          style={{
+            minWidth: 90,
+            paddingVertical: 8,
+            paddingHorizontal: 15,
+            borderWidth: 1,
+            borderColor: "aqua",
+            borderRadius: 8,
+            backgroundColor: "#191919",
+            alignItems: "center",
+          }}
+        >
+          <Text
+            style={{
+              color: "white",
+              fontSize: accessMode ? 18 : 16,
+              fontWeight: "bold",
+            }}
+          >
+            {selectedYear}
+          </Text>
+        </View>
+
+        <TouchableOpacity
+          onPress={selectNextYear}
+          disabled={currentIndex <= 0}
+          style={{
+            paddingHorizontal: 15,
+            paddingVertical: 5,
+          }}
+        >
+          <Text
+            style={{
+              color: currentIndex <= 0 ? "gray" : "aqua",
+              fontSize: 24,
+            }}
+          >
+            ▶
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
+
+export default YearSelector;


### PR DESCRIPTION
## Titel  
### Add selectable year view for WorkHours chart — year selector + tooltip date improvements

## Type of Changes 
- [x] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintanance work 
- [x] 🎭 ui: Ui changes  

## Changes  
- Add `selectedYear` state to the `WorkHoursChart` component.
- Add dynamic year filtering for the year chart based on the selected year.
- Add available year calculation from existing Firestore work hour data.
- Add new `YearSelector` component integration for switching between available years.
- Update year view tooltip and worktime overview date formatting to include the selected year (e.g. `July 2025` instead of only `July`).
- Keep existing chart aggregation logic for monthly bars while allowing year selection.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed 
- `components/WorkHoursChart.tsx` (updated)
- `components/FormatToolTip.ts` (updated)
- `components/YearSelector.tsx` (added)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies
No dependency changes.

## Notes
- The year selector allows users to navigate between years available in Firestore data.
- The existing monthly aggregation remains unchanged; only the selected year filter and display formatting were extended.