### PR TITLE
Fix/GitHub actions workflows

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+  permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,31 +1,30 @@
 name: Deploy Firestore Rules
 
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - master
 
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
+  deploy:
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22.22.2
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.22.2
 
-            - name: Install Firebase CLI
-              run: npm install -g firebase-tools
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
 
-            - name: Write service account key
-              run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > $HOME/gcloud.json
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
-            - name: Set credentials
-              run: echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud.json" >> $GITHUB_ENV
-
-            - name: Deploy Firestore Rules
-              run: firebase deploy --only firestore:rules --project chrono-craft-worktime-manager
+      - name: Deploy Firestore Rules
+        run: firebase deploy --only firestore:rules --project chrono-craft-worktime-manager

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -118,11 +118,10 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
-      - name: Write service account key
-        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > $HOME/gcloud.json
-
-      - name: Set credentials
-        run: echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud.json" >> $GITHUB_ENV
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
 
       - name: Validate Firestore Rules
         run: firebase deploy --only firestore:rules --dry-run --project chrono-craft-worktime-manager


### PR DESCRIPTION
## Titel  
### Fix Firebase CI authentication — replace manual credentials setup with Google Cloud auth action

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Dokumentation changes  
- [ ] 🎨 style: Change rendering 
- [ ] 🧪 test: Tests added or changed  
- [x] 🔧 chore: Maintenance work 
- [ ] 🎭 ui: UI changes  

## Changes  
- Replace manual `GOOGLE_APPLICATION_CREDENTIALS` setup in Firebase workflows with `google-github-actions/auth@v2`.
- Update `Security CI` workflow to authenticate Firebase Rules validation using `FIREBASE_SERVICE_ACCOUNT`.
- Update `Deploy Firestore Rules` workflow to use the same Google Cloud authentication mechanism.
- Keep Firestore Rules and Storage Rules validation/deployment commands unchanged after authentication step.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed 
- `.github/workflows/security-ci.yml` (updated)
- `.github/workflows/deploy-firestore-rules.yml` (updated)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [ ] My changes generate no new warnings

## Dependencies
No dependency changes.

## Notes
- The previous Firebase authentication approach only exported `GOOGLE_APPLICATION_CREDENTIALS` manually and caused GitHub Actions to fail with `Failed to authenticate, have you run firebase login?`.
- Using `google-github-actions/auth@v2` provides the recommended GitHub Actions authentication flow for Google Cloud service accounts.