### PR TITLE
test: replace unsafe sanitizer test with profile field trimming validation

### DIFF
--- a/functions/tests/unit/services/profileService.test.ts
+++ b/functions/tests/unit/services/profileService.test.ts
@@ -9,6 +9,12 @@
 jest.mock("../../../src/repos/userRepo");
 jest.mock("../../../src/utils/logger");
 
+jest.mock("../../../src/functions/security", () => ({
+  InputValidator: {
+    sanitizeString: (input: string) => input.replace(/[<>]/g, "").trim(),
+  },
+}));
+
 ///////////////////////////////////////////////////////////////////////////////
 
 import { ProfileService } from "../../../src/services/profileService";
@@ -78,23 +84,22 @@ describe("ProfileService Unit Tests", () => {
       ).rejects.toThrow("Database error");
     });
 
-    it("should sanitize displayName and personalNumber", async () => {
+    it("should trim displayName and personalNumber before update", async () => {
+      const uid = "user123";
+
       const updateData = {
-        displayName: '<script>alert("xss")</script>New Name',
-        personalNumber: "PN-<b>00123</b>",
+        displayName: " New Name ",
+        personalNumber: " PN-00123 ",
       };
 
-      const sanitize = (input: string) =>
-        input
-          .replace(/<[^>]*>/g, "")
-          .replace(/alert\([^)]*\)/g, "")
-          .trim();
+      mockUserRepo.updateUser.mockResolvedValue(undefined);
 
-      const sanitizedDisplayName = sanitize(updateData.displayName);
-      const sanitizedPersonalNumber = sanitize(updateData.personalNumber);
+      await profileService.updateProfile(uid, updateData);
 
-      expect(sanitizedDisplayName).toBe("New Name");
-      expect(sanitizedPersonalNumber).toBe("PN-00123");
+      expect(mockUserRepo.updateUser).toHaveBeenCalledWith(uid, {
+        displayName: "New Name",
+        personalNumber: "PN-00123",
+      });
     });
 
     describe("uid handling", () => {


### PR DESCRIPTION
## Title  
### Replace unsafe sanitizer test with profile field trimming validation

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [ ] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Change rendering/style only  
- [x] 🧪 test: Test changes  
- [ ] 🔐 security: Security improvements  

## Description

The existing `ProfileService` unit test contained a custom regex-based sanitization implementation:

- `<[^>]*>` pattern to remove HTML tags
- `alert(...)` pattern matching

This implementation was detected by GitHub CodeQL as an "Incomplete multi-character sanitization" issue.

The test was updated to avoid duplicating security logic and instead verify the actual behavior implemented by `ProfileService`.

## Changes

Removed:
- Custom sanitizer implementation inside `profileService.test.ts`
- Security-related logic duplicated in the unit test

Added:
- Test coverage for the actual normalization behavior of `ProfileService`
- Verification that `displayName` and `personalNumber` values are trimmed before updating

## Security Impact

- Resolves GitHub CodeQL alert:
  - `js/incomplete-multi-character-sanitization`

- No production code changes required.
- The test no longer contains a custom sanitization implementation that could introduce misleading security assumptions.

## Testing

- [x] Unit tests executed successfully
- [x] CodeQL alert resolved

## Notes

Input sanitization remains handled by the upstream security layer (`secureCore` / `InputValidator`) and is intentionally not duplicated inside the `ProfileService` unit tests.