### PR TITLE
Fix/mfa state management

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -200,7 +200,7 @@ const AppNavigator = () => {
         targetRoute = "Inside";
         break;
       case "pendingMfa":
-        if (isMFAEnabled) targetRoute = "MfaScreen";
+        targetRoute = "MfaScreen";
         break;
       default:
         targetRoute = "Login";

--- a/Screens/LoginScreen.tsx
+++ b/Screens/LoginScreen.tsx
@@ -116,10 +116,6 @@ const LoginScreen: React.FC = () => {
       // === Single state transition point ===
       setUser(user);
       setStage(nextStage);
-
-      if (nextStage === "pendingMfa") {
-        navigation.navigate("MfaScreen" as never);
-      }
     } catch (error) {
       logError("LoginScreen/login", error);
       useAlertStore

--- a/Screens/MfaScreen.tsx
+++ b/Screens/MfaScreen.tsx
@@ -89,9 +89,12 @@ const MfaScreen: React.FC = () => {
       }
 
       if (res.data.valid) {
+        await user?.getIdToken(true);
+
         useAlertStore
           .getState()
           .showAlert("Success", "Authentication successful.");
+
         setStage("authenticated");
       } else {
         useAlertStore

--- a/components/WorkHoursState.tsx
+++ b/components/WorkHoursState.tsx
@@ -10,7 +10,7 @@ import { getAuth } from "firebase/auth";
 import { doc, setDoc, getDoc } from "firebase/firestore";
 
 import { FIREBASE_FIRESTORE } from "../firebaseConfig";
-import { logError, logWarn } from "../lib/loggerClient";
+import { logError } from "../lib/loggerClient";
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/components/WorkTimeAnimation.tsx
+++ b/components/WorkTimeAnimation.tsx
@@ -55,10 +55,10 @@ const Circle: React.FC<CircleProps> = ({
 }) => {
   // calculate progress once per component
   const circleProgress = useDerivedValue(
-    () => (sharedProgress.value + circleOffset) % 1
+    () => (sharedProgress.value + circleOffset) % 1,
   );
   const outlineProgress = useDerivedValue(
-    () => (sharedProgress.value + outlineOffset) % 1
+    () => (sharedProgress.value + outlineOffset) % 1,
   );
 
   // animated style for the outer circle
@@ -70,14 +70,14 @@ const Circle: React.FC<CircleProps> = ({
           scale: interpolate(
             progress,
             INTERPOLATION_INPUT,
-            CIRCLE_SCALE_OUTPUT
+            CIRCLE_SCALE_OUTPUT,
           ),
         },
       ],
       opacity: interpolate(
         progress,
         INTERPOLATION_INPUT,
-        CIRCLE_OPACITY_OUTPUT
+        CIRCLE_OPACITY_OUTPUT,
       ),
     };
   });
@@ -101,14 +101,14 @@ const Circle: React.FC<CircleProps> = ({
           scale: interpolate(
             progress,
             INTERPOLATION_INPUT,
-            OUTLINE_SCALE_OUTPUT
+            OUTLINE_SCALE_OUTPUT,
           ),
         },
       ],
       opacity: interpolate(
         progress,
         INTERPOLATION_INPUT,
-        OUTLINE_OPACITY_OUTPUT
+        OUTLINE_OPACITY_OUTPUT,
       ),
     };
   });
@@ -137,7 +137,7 @@ const WorkTimeAnimation = () => {
         easing: Easing.inOut(Easing.ease),
       }),
       -1,
-      false
+      false,
     );
   }, [sharedProgress]);
 

--- a/components/contexts/AuthContext.tsx
+++ b/components/contexts/AuthContext.tsx
@@ -32,7 +32,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       if (firebaseUser) {
         await firebaseUser.getIdToken(true);
         setUser(firebaseUser);
-        setStage("authenticated");
+
+        // Firebase session exists.
+        // The real auth stage (MFA pending/authenticated)
+        // is determined after login validation.
+        setStage((currentStage) =>
+          currentStage === "pendingMfa" ? "pendingMfa" : "authenticated",
+        );
       } else {
         setUser(null);
         setStage("loggedOut");


### PR DESCRIPTION
## Titel  
### Fix MFA authentication flow state handling

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [ ] 🔧 chore: Maintanance work  
- [x] 🐛 fix: Bugfix  
- [x] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Change rendering  
- [ ] 🧪 test: Tests added or changed
- [ ] ⚡ perf: Performance improvement   
- [ ] 🎭 ui: Ui changes
- [ ] 🔒 security: Security improvement 

## Description

Fixed MFA authentication flow issues caused by conflicting authentication state handling between Firebase Auth state restoration and the application auth stage management.

The previous implementation allowed Firebase `onAuthStateChanged` to immediately set the user state to `authenticated`, even when MFA verification was still pending. This caused the app to briefly navigate to the HomeScreen before opening the MFA confirmation screen.

## Changes

- Prevented `AuthContext` from overriding an active `pendingMfa` state.
- Simplified MFA routing logic in `AppNavigator`.
- Removed duplicate MFA navigation handling from `LoginScreen`.
- Refreshed Firebase ID token after successful TOTP verification to apply updated authentication claims.

## Bug Fixes

Fixed:

- MFA screen appearing after HomeScreen during login.
- MFA confirmation flow not completing correctly after TOTP validation.
- Inconsistent authentication state after Firebase session restoration.

## Testing

Tested on real Android device:

-  ✅Login with enabled MFA
-  ✅MFA confirmation with valid TOTP
-  ✅Invalid TOTP handling
-  ✅Password reset MFA flow
-  ✅App restart authentication flow

## Security Impact

Improves authentication state consistency by ensuring that access to authenticated routes only occurs after the required MFA verification step has completed.

No new security mechanisms introduced.