### PR TITLE
Fix/disable horizontal scroll details screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -253,6 +253,7 @@ const AppNavigator = () => {
         component={DetailsScreen as any}
         initialParams={{ projectId: "" }}
         options={({ navigation }) => ({
+          gestureEnabled: false,
           headerShown: true,
           presentation: "modal",
           animationTypeForReplace: "push",


### PR DESCRIPTION
## Titel
### Disable swipe navigation on the Details screen

## Type of Changes
- [ ] ✨ feat: New Feature
- [x] 🐛 fix: Bugfix
- [ ] 🔄 refactor: Code Refactoring
- [ ] 🔐 security: Security Improvement
- [ ] 🧪 test: Tests
- [ ] 📚 docs: Documentation
- [ ] ⚙️ chore: Maintenance

## Description

Disabled gesture-based navigation on the Details screen.

The screen could previously be left by swiping horizontally, which could result in an unintended white screen. Navigation from the Details screen is now only possible through the existing back button, which already contains the required tracking-state validation.

## Changes Made

- Disabled swipe navigation for the `Details` stack screen
- Preserved existing header back button behavior
- Kept project tracking validation unchanged before leaving the screen

## Testing

- ✅ Opened a project from the Home screen
- ✅ Verified horizontal swipe gestures no longer navigate away from the Details screen
- ✅ Verified vertical scrolling still works as expected
- ✅ Verified the header back button still navigates correctly
- ✅ Verified active project tracking still prevents leaving the screen

## Notes

This change prevents accidental navigation and eliminates the white screen that could appear when swiping horizontally on the Details screen.