### PR TITLE
Fix/config ci to dependabot

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -108,6 +108,7 @@ jobs:
   # ---------------------------
   rules-security:
     name: Firebase Rules Security
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Titel  
### Skip authenticated Firebase Rules validation for Dependabot PRs

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🔧 chore: Maintanance work  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Change rendering  
- [ ] 🧪 test: Tests added or changed
- [ ] ⚡ perf: Performance improvement   
- [ ] 🎭 ui: Ui changes
- [ ] 🔒 security: Security improvement 

## Changes  
- Skip `rules-security` workflow job for Dependabot pull requests.
- Prevent CI failures caused by unavailable GitHub secrets in Dependabot workflows.
- Keep Firebase Rules validation active for regular pull requests and pushes.

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed 
- `.github/workflows/security.yml` (updated)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies
No dependency changes.

## Notes
- Dependabot workflows do not receive repository secrets by default.
- The Firebase authentication step requires `FIREBASE_SERVICE_ACCOUNT`, so the rules validation job is skipped for Dependabot PRs to avoid unnecessary authentication failures.
- Regular CI runs continue to validate Firebase Rules with the configured service account.