### PR TITLE
Fix/add protobufjs override in functions modul

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -2734,12 +2734,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -8996,9 +8990,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9008,7 +9002,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -23,6 +23,9 @@
     "firebase-functions": "^7.2.5",
     "resend": "^6.10.0"
   },
+  "overrides": {
+    "protobufjs": "7.6.5"
+  },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",
     "@types/jest": "^29.0.0",


### PR DESCRIPTION
## Titel  
### Patch protobufjs transitive dependency vulnerability in Firebase Functions

## Type of Changes 
- [ ] ✨ feat: New Feature  
- [x] 🔧 chore: Maintanance work  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Change rendering  
- [ ] 🧪 test: Tests added or changed
- [ ] ⚡ perf: Performance improvement   
- [ ] 🎭 ui: Ui changes
- [x] 🔒 security: Security improvement 

## Changes  
- Add `protobufjs` override to `functions/package.json` to enforce patched version `7.6.5`.
- Refresh `functions/package-lock.json` to resolve transitive `protobufjs` dependency versions.
- Patch vulnerable transitive dependency paths introduced by:
  - `firebase-functions`
  - `firebase-admin`
  - `firebase`

## Tests  
- [x] ✅ Changes are tested 
- [ ] 🚫 No tests necessary 

## Files changed 
- `functions/package.json` (updated)
- `functions/package-lock.json` (updated)

## Checklist
- [x] My changes are well-tested and commented
- [x] I reviewed my changes
- [x] My changes generate no new warnings

## Dependencies
- Added `protobufjs@7.6.5` override to patch transitive dependency vulnerabilities.
- No direct dependency upgrades performed.

## Notes
- Resolves `protobufjs` vulnerabilities:
  - Denial of Service via infinite loop in `.proto` option parsing.
  - Schema-derived names can shadow runtime-significant properties.
- The vulnerability affected transitive dependencies only.
- The override ensures all affected dependency paths use the patched version `7.6.5`.