### PR TITLE
fix (sec): update fast-uri from v3.1.3 to v3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12997,9 +12997,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "tar": "^7.5.20",
     "fast-xml-parser": "^5.7.0",
     "brace-expansion": "^5.0.7",
-    "fast-uri": "^3.1.3",
+    "fast-uri": "^3.1.5",
     "js-yaml": "^4.1.1",
     "postcss": "^8.5.18",
     "semver": "^7.7.2",


### PR DESCRIPTION
## Titel

### Patch fast-uri vulnerability via npm override

## Type of Changes

- [ ] ✨ feat: New Feature
- [ ] 🔧 chore: Maintanance work
- [ ] 🐛 fix: Bugfix
- [ ] 🔄 refactor: Code Refactoring
- [ ] 📖 docs: Documentation changes
- [ ] 🎨 style: Change rendering
- [ ] 🧪 test: Tests added or changed
- [ ] ⚡ perf: Performance improvement
- [ ] 🎭 ui: Ui changes
- [x] 🔒 security: Security improvement

## Changes

- Update the root `fast-uri` npm override from `^3.1.3` to `^3.1.5`.
- Resolve the transitive `fast-uri` dependency introduced through `expo-build-properties` → `ajv`.
- Update `package-lock.json` to resolve the patched `fast-uri` version.
- Prevent the vulnerable `fast-uri` version `3.1.4` from being installed.

## Tests

- [x] ✅ Changes are tested
- [ ] 🚫 No tests necessary

## Files changed

- `package.json` (updated)
- `package-lock.json` (updated)

## Dependencies

- No direct dependency added.
- `fast-uri` remains a transitive dependency and is controlled via the existing root `overrides` configuration.

## Notes

- Fixes the Dependabot alert for `fast-uri` versions `>= 3.0.0, < 3.1.5`.
- Patched version: `fast-uri@3.1.5`.
- The vulnerability can cause a host parsing discrepancy between `fast-uri` and Node.js WHATWG URL parsing, potentially bypassing host-based URL validation.
- No unrelated dependency upgrades are intended as part of this security fix.