### PR TITLE
fix: add margin to the date object in the projectListItem

### DIFF
--- a/components/projectListItem.tsx
+++ b/components/projectListItem.tsx
@@ -141,6 +141,8 @@ const ProjectListItem: React.FC<Props> = ({
                 style={{
                   color: accessMode ? "white" : "grey",
                   fontSize: 14,
+                  marginTop: 5,
+                  marginLeft: 10,
                 }}
               >
                 {dayjs(dateObj).format("DD.MM.YYYY")}


### PR DESCRIPTION
## Titel  
### Add spacing to project list item date

## Type of Changes  
- [ ] ✨ feat: New Feature  
- [ ] 🔧 chore: Maintanance work  
- [ ] 🐛 fix: Bugfix  
- [ ] 🔄 refactor: Code Refactoring  
- [ ] 📖 docs: Documentation changes  
- [ ] 🎨 style: Change rendering  
- [ ] 🧪 test: Tests added or changed  
- [ ] ⚡ perf: Performance improvement  
- [x] 🎭 ui: Ui changes  
- [ ] 🔒 security: Security improvement  

## Changes  
- Add `marginTop: 5` to the project list item date.
- Add `marginLeft: 10` to improve spacing and visual alignment.

## Tests  
- [ ] ✅ Changes are tested  
- [x] 🚫 No tests necessary  

## Files changed  
- `components/ProjectListItem.tsx` (updated)

## Checklist 
- [x] My changes are well-tested and commented  
- [x] I reviewed my changes  
- [x] My changes generate no new warnings  

## Dependencies  
None.

## Notes  
- UI-only spacing adjustment for the date section in `ProjectListItem`.