### PR TITLE
ui: deleted copilot title because context is redundant

### DIFF
--- a/components/services/copilotTour/CopilotOffset.ts
+++ b/components/services/copilotTour/CopilotOffset.ts
@@ -7,18 +7,17 @@
 //////////////////////////////////////////////////////////////////////////////
 
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useWindowDimensions, PixelRatio, Platform } from "react-native";
+import { useWindowDimensions, PixelRatio } from "react-native";
 import { useEffect, useState } from "react";
 
 //////////////////////////////////////////////////////////////////////////////
 
 export const useCopilotOffset = () => {
   const { top } = useSafeAreaInsets();
-  const { height, width } = useWindowDimensions();
+  const { height } = useWindowDimensions();
   const [offset, setOffset] = useState(25); // default offset
 
   useEffect(() => {
-    const scale = PixelRatio.get();
     let calculatedOffset = Math.min(height * 0.045, 60) + top;
 
     if (height < 700) {

--- a/components/services/copilotTour/CustomToolTip.tsx
+++ b/components/services/copilotTour/CustomToolTip.tsx
@@ -27,7 +27,6 @@ const CustomTooltip = () => {
   const accessMode = useAccessibilityStore(
     (state) => state.accessibilityEnabled,
   );
-  // console.log("accessMode in LoginScreen:", accessMode);
 
   // functions to navigate to the next or previous step
   const handleStop = () => {
@@ -54,19 +53,6 @@ const CustomTooltip = () => {
         width: 250,
       }}
     >
-      {/* Tooltip Title */}
-      <Text
-        accessibilityRole="header"
-        style={{
-          fontWeight: "bold",
-          color: "#FFF",
-          fontSize: accessMode ? 28 : 18,
-          marginBottom: 8,
-        }}
-      >
-        {currentStep?.name}
-      </Text>
-
       {/* Tooltip Text */}
       <Text
         style={{


### PR DESCRIPTION
## Titel   
### Remove redundant Copilot Tour title and unused platform/width values

## Type of Changes  
- [ ] ✨ feat: New Feature   
- [x] 🔧 chore: Maintanance work   
- [ ] 🐛 fix: Bugfix   
- [ ] 🔄 refactor: Code Refactoring   
- [ ] 📖 docs: Documentation changes   
- [ ] 🎨 style: Change rendering   
- [ ] 🧪 test: Tests added or changed 
- [ ] ⚡ perf: Performance improvement    
- [x] 🎭 ui: Ui changes 
- [ ] 🔒 security: Security improvement  
 
## Changes   
- Remove the redundant `Copilot Tour` title from the `CopilotTour` component.
- Keep the existing screen titles as the primary context for the user.
- Remove the unused `Platform` import from `CopilotOffset.ts`.
- Remove the unused `width` value from `useWindowDimensions()`.
 
## Tests   
- [x] ✅ Changes are tested  
- [ ] 🚫 No tests necessary  
 
## Files changed  
- `components/services/copilotTour/CopilotTour.tsx` (updated)
- `components/services/copilotTour/CopilotOffset.ts` (updated)
 

## Dependencies 
None
 
## Notes 
- The navigation drawer already provides the context of the destination screen, making the additional `Copilot Tour` title redundant.
- Unused `Platform` and `width` values were removed from `CopilotOffset.ts`.